### PR TITLE
refactor: move timestamp into message metadata

### DIFF
--- a/ragnarbot/bus/events.py
+++ b/ragnarbot/bus/events.py
@@ -1,7 +1,6 @@
 """Event types for the message bus."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any
 
 
@@ -13,7 +12,6 @@ class InboundMessage:
     sender_id: str  # User identifier
     chat_id: str  # Chat/channel identifier
     content: str  # Message text
-    timestamp: datetime = field(default_factory=datetime.now)
     media: list[str] = field(default_factory=list)  # Media URLs
     metadata: dict[str, Any] = field(default_factory=dict)  # Channel-specific data
     

--- a/ragnarbot/session/manager.py
+++ b/ragnarbot/session/manager.py
@@ -38,7 +38,7 @@ class Session:
         msg = {
             "role": role,
             "content": content or "",
-            "timestamp": datetime.now().isoformat(),
+            "metadata": {"timestamp": datetime.now().isoformat()},
             **kwargs
         }
         self.messages.append(msg)


### PR DESCRIPTION
## Summary

- Remove dead `timestamp` field from `InboundMessage` (was never read anywhere)
- Nest session message timestamp inside `metadata` dict for future extensibility
- No migration needed — old sessions with top-level `timestamp` continue working since the field was never read