### PR TITLE
fix(loop): remove tool iteration limit

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -46,7 +46,6 @@ class AgentLoop:
         provider: LLMProvider,
         workspace: Path,
         model: str | None = None,
-        max_iterations: int = 20,
         brave_api_key: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         cron_service: "CronService | None" = None,
@@ -62,7 +61,6 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
-        self.max_iterations = max_iterations
         self.brave_api_key = brave_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
@@ -412,13 +410,11 @@ class AgentLoop:
         new_start = len(messages) - len(batch)
 
         # Agent loop
-        iteration = 0
         final_content = None
         compacted_this_turn = False
 
         try:
-            while iteration < self.max_iterations:
-                iteration += 1
+            while True:
 
                 # Cache flush escalation (if TTL expired)
                 flushed = False
@@ -734,14 +730,12 @@ class AgentLoop:
         # Track where new messages start
         new_start = len(messages) - 1
 
-        # Agent loop (limited for announce handling)
-        iteration = 0
+        # Agent loop
         final_content = None
         compacted_this_turn = False
 
         try:
-            while iteration < self.max_iterations:
-                iteration += 1
+            while True:
 
                 # Cache flush escalation (if TTL expired)
                 flushed = False

--- a/ragnarbot/agent/subagent.py
+++ b/ragnarbot/agent/subagent.py
@@ -114,14 +114,11 @@ class SubagentManager:
                 {"role": "user", "content": task},
             ]
             
-            # Run agent loop (limited iterations)
-            max_iterations = 15
-            iteration = 0
+            # Run agent loop
             final_result: str | None = None
-            
-            while iteration < max_iterations:
-                iteration += 1
-                
+
+            while True:
+
                 response = await self.provider.chat(
                     messages=messages,
                     tools=tools.get_definitions(),

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -258,7 +258,6 @@ def gateway_main(
         provider=provider,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
-        max_iterations=config.agents.defaults.max_tool_iterations,
         brave_api_key=brave_api_key,
         exec_config=config.tools.exec,
         cron_service=cron,

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -27,7 +27,6 @@ class AgentDefaults(BaseModel):
     model: str = "anthropic/claude-opus-4-6"
     max_tokens: int = 8192
     temperature: float = 0.7
-    max_tool_iterations: int = 20
     max_context_tokens: int = 200_000
     auth_method: str = "api_key"
     stream_steps: bool = True  # Send intermediate messages to user during tool-call loops


### PR DESCRIPTION
## Summary

- Removed the hardcoded `max_iterations` cap (was 20 for the main agent loop, 15 for subagents)
- Agent loops now run until the LLM naturally stops issuing tool calls (`while True` + `break` on no tool calls)
- Removed `max_tool_iterations` from config schema and all wiring in CLI/loop constructor