### PR TITLE
fix(compactor): preserve session history during compaction

### DIFF
--- a/ragnarbot/agent/compactor.py
+++ b/ragnarbot/agent/compactor.py
@@ -267,7 +267,6 @@ class Compactor:
             },
         }
 
-        # Remove all messages before the tail (they're now compacted)
+        # Insert compaction marker before the tail
         insert_idx = len(session.messages) - tail_count
-        # Replace everything before tail with compaction message
-        session.messages = [compaction_msg] + session.messages[insert_idx:]
+        session.messages.insert(insert_idx, compaction_msg)


### PR DESCRIPTION
## Summary

- Replace destructive list reassignment in `_inject_compaction` with a non-destructive `insert()` — full conversation history is now preserved in the JSONL session file
- Compaction marker is inserted before the tail instead of replacing all pre-tail messages
- No changes needed to `get_history()`, `_find_last_compaction_idx()`, or `save()` — they already handle preserved history correctly