### PR TITLE
feat(prompts): split TOOLS.md into builtin prompt + dynamic workspace file

### DIFF
--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -144,6 +144,21 @@ Information about the user goes here.
 - Timezone: (your timezone)
 - Language: (your preferred language)
 """,
+        "TOOLS.md": """# Tool Preferences & Custom Notes
+
+This file is maintained by the agent based on conversations with the user.
+It stores user preferences, custom scripts, workflows, and tool-related
+notes learned over time.
+
+DO NOT clear or overwrite this header. Only append new sections below the separator.
+Document here when the user:
+- Expresses a preference about how a tool should be used
+- Sets up a custom workflow or script
+- Wants specific tool behavior remembered across sessions
+
+---
+
+""",
     }
 
     for filename, content in templates.items():

--- a/ragnarbot/prompts/tools.py
+++ b/ragnarbot/prompts/tools.py
@@ -1,0 +1,74 @@
+"""Builtin tool usage context for the agent."""
+
+TOOLS_CONTEXT = """# Tool Usage Guide
+
+## File Tools
+
+### file_read
+Read a file's contents. Always read a file before editing it — you need to see the current content to construct an accurate edit.
+
+### write_file
+Write content to a file (creates parent directories automatically). Use for creating new files. For modifying existing files, prefer `edit_file` instead.
+
+### edit_file
+Replace a specific text block in an existing file. Provide the exact `old_text` to match — it must appear exactly once. Include enough surrounding context to make the match unique. Always `file_read` the file first.
+
+### list_dir
+List directory contents. Use to explore project structure or check what files exist before acting.
+
+## Shell
+
+### exec
+Execute a shell command. Returns stdout, stderr, and exit code.
+- Has a timeout (commands that run too long are killed).
+- Destructive commands (rm -rf, format, dd, etc.) are blocked by safety guards.
+- Provide `working_dir` when the command must run in a specific directory.
+- For long-running processes, warn the user about potential timeout.
+
+## Web Tools
+
+### web_search
+Search the web via Brave Search. Returns titles, URLs, and snippets. Use when the user asks a question that needs current information, or when you need to look something up.
+
+### web_fetch
+Fetch a URL and extract its content as markdown or plain text. Use when you have a specific URL to read (from search results, user-provided links, documentation). Set `extractMode` to "text" for simpler output or "markdown" (default) for structured content.
+
+## Message
+
+### message
+Send a message to a specific channel and chat. In normal conversation, you do NOT need this tool — just respond with text directly. Use `message` only when:
+- You need to send an intermediate status update during a multi-step tool operation
+- You need to deliver a message to a different channel or chat than the current one
+
+## Subagents
+
+### spawn
+Spawn a background subagent to handle a task independently. Good for:
+- Tasks that take many steps and can run without user interaction
+- Research or data-gathering that would take multiple tool calls
+- Work that doesn't need back-and-forth with the user
+
+The subagent gets its own tool access and reports back when done. Give it a clear, self-contained task description.
+
+## Scheduling
+
+### cron
+Schedule recurring tasks or reminders. Actions:
+- `add` — create a job. Requires `message` and either `every_seconds` (interval) or `cron_expr` (cron syntax like "0 9 * * *" for daily at 9am).
+- `list` — show all scheduled jobs.
+- `remove` — delete a job by `job_id`.
+
+Jobs run through the agent and deliver responses to the user's chat.
+
+## Downloads
+
+### download_file
+Download a file that the user shared in chat. When a user sends a document, voice message, or other file, you'll see a `[file available: ...]` marker with a `file_id`. Pass that `file_id` to this tool to download and access the file locally.
+
+## General Principles
+
+- **Explain before acting**: Tell the user what you're about to do before executing commands or making changes.
+- **Read before writing**: Always read a file before editing it. Don't guess at contents.
+- **Minimal changes**: Only modify what's needed. Don't refactor surrounding code unless asked.
+- **Check results**: After writing or editing files, verify the operation succeeded before moving on.
+"""


### PR DESCRIPTION
## Summary

- Add static `TOOLS_CONTEXT` prompt (`ragnarbot/prompts/tools.py`) with usage guidance for all non-Telegram tools (file ops, shell, web, message, spawn, cron, download)
- Auto-create dynamic `TOOLS.md` in workspace on first context build — agent maintains it with user preferences and custom workflows over time
- Add `TOOLS.md` to workspace templates so `ragnarbot init` also creates it