### PR TITLE
fix(telegram): use single source of truth for bot menu commands

### DIFF
--- a/ragnarbot/channels/telegram.py
+++ b/ragnarbot/channels/telegram.py
@@ -17,6 +17,19 @@ from ragnarbot.media.manager import MediaManager
 from ragnarbot.providers.transcription import TranscriptionError, TranscriptionProvider
 
 
+BOT_COMMANDS = [
+    ("new", "Start a new conversation"),
+    ("context", "Show context usage"),
+    ("context_mode", "Change context mode"),
+]
+
+
+async def set_bot_commands(bot) -> None:
+    """Set the bot command menu. Single source of truth for all command lists."""
+    from telegram import BotCommand
+    await bot.set_my_commands([BotCommand(cmd, desc) for cmd, desc in BOT_COMMANDS])
+
+
 def _markdown_to_telegram_html(text: str) -> str:
     """
     Convert markdown to Telegram-safe HTML.
@@ -267,12 +280,7 @@ class TelegramChannel(BaseChannel):
         bot_info = await self._app.bot.get_me()
         logger.info(f"Telegram bot @{bot_info.username} connected")
 
-        from telegram import BotCommand
-        await self._app.bot.set_my_commands([
-            BotCommand("new", "Start a new conversation"),
-            BotCommand("context", "Show context usage"),
-            BotCommand("context_mode", "Change context mode"),
-        ])
+        await set_bot_commands(self._app.bot)
         
         # Register media download callback
         if self.media_manager:

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -528,7 +528,9 @@ def telegram_grant_access(
         import asyncio
 
         async def _send_confirmation():
-            from telegram import Bot, BotCommand
+            from telegram import Bot
+
+            from ragnarbot.channels.telegram import set_bot_commands
             bot = Bot(token=bot_token)
             async with bot:
                 await bot.send_message(
@@ -539,9 +541,7 @@ def telegram_grant_access(
                     ),
                     parse_mode="HTML",
                 )
-                await bot.set_my_commands([
-                    BotCommand("new", "Start a new conversation"),
-                ])
+                await set_bot_commands(bot)
 
         try:
             asyncio.run(_send_confirmation())


### PR DESCRIPTION
## Summary

- Grant-access flow was overwriting the global bot command menu with only `/new`, removing `/context` and `/context_mode` for all users
- Extracted `BOT_COMMANDS` constant and `set_bot_commands()` helper in `telegram.py` so both startup and grant-access use the same list