### PR TITLE
fix(tui): skip newlines in pasted input during onboarding

### DIFF
--- a/ragnarbot/cli/tui/keys.py
+++ b/ragnarbot/cli/tui/keys.py
@@ -99,6 +99,8 @@ def read_key() -> tuple[Key, str]:
                 if select.select([fd], [], [], 0.01)[0]:
                     os.read(fd, 2)
                 continue
+            if more_ch in ("\r", "\n"):
+                continue  # skip newlines from terminal line-wrapping in paste
             _input_buffer.append(_byte_to_key(more_ch))
 
         return first


### PR DESCRIPTION
## Summary

- Tokens copied from narrow terminals include line-wrap newlines (`\n`) that were interpreted as Enter, splitting the input and leaking leftover characters into the next screen
- Skip `\r`/`\n` in the paste drain loop in `keys.py` so the full token is captured as a single string
- Affects all `text_input()` fields: Telegram token, LLM API key, transcription key, model name