### PR TITLE
feat(web): add browser-based chat channel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "rich>=13.0.0",
     "croniter>=2.0.0",
     "python-telegram-bot>=21.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.optional-dependencies]
@@ -56,6 +57,7 @@ include = [
     "ragnarbot/**/*.py",
     "ragnarbot/skills/**/*.md",
     "ragnarbot/skills/**/*.sh",
+    "ragnarbot/channels/web_static/**",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/ragnarbot/channels/manager.py
+++ b/ragnarbot/channels/manager.py
@@ -62,8 +62,20 @@ class ChannelManager:
                 logger.info("Telegram channel enabled")
             except ImportError as e:
                 logger.warning(f"Telegram channel not available: {e}")
-        
-    
+
+        # Web channel
+        if self.config.channels.web.enabled:
+            try:
+                from ragnarbot.channels.web import WebChannel
+                self.channels["web"] = WebChannel(
+                    self.config.channels.web,
+                    self.bus,
+                )
+                logger.info("Web channel enabled")
+            except ImportError as e:
+                logger.warning(f"Web channel not available: {e}")
+
+
     async def start_all(self) -> None:
         """Start all channels and the outbound dispatcher."""
         if not self.channels:

--- a/ragnarbot/channels/web.py
+++ b/ragnarbot/channels/web.py
@@ -1,0 +1,186 @@
+"""Web channel — browser-based chat via WebSocket."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+from aiohttp.web import WebSocketResponse
+from loguru import logger
+
+from ragnarbot.bus.events import OutboundMessage
+from ragnarbot.bus.queue import MessageBus
+from ragnarbot.channels.base import BaseChannel
+from ragnarbot.config.schema import WebConfig
+
+STATIC_DIR = Path(__file__).parent / "web_static"
+
+
+class WebChannel(BaseChannel):
+    """Chat channel served over HTTP + WebSocket."""
+
+    name = "web"
+
+    def __init__(self, config: WebConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self._connections: dict[str, WebSocketResponse] = {}
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def is_allowed(self, sender_id: str) -> bool:
+        # Localhost — no auth required.
+        return True
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        self._app = web.Application()
+        self._app.router.add_get("/", self._handle_index)
+        self._app.router.add_get("/ws", self._handle_websocket)
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+
+        site = web.TCPSite(
+            self._runner,
+            self.config.host,
+            self.config.port,
+        )
+        await site.start()
+        self._running = True
+        logger.info(
+            "Web channel listening on http://{}:{}",
+            self.config.host,
+            self.config.port,
+        )
+
+        # Block forever so ChannelManager.start_all keeps this task alive.
+        import asyncio
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self) -> None:
+        self._running = False
+
+        # Close every open WS connection.
+        for ws in list(self._connections.values()):
+            await ws.close()
+        self._connections.clear()
+
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+
+        logger.info("Web channel stopped")
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    async def send(self, msg: OutboundMessage) -> None:
+        ws = self._connections.get(msg.chat_id)
+        if not ws or ws.closed:
+            return
+
+        # Typing indicator
+        if msg.metadata.get("chat_action") == "typing":
+            await self._ws_send(ws, {"type": "typing", "active": True})
+            return
+
+        is_intermediate = msg.metadata.get("intermediate", False)
+
+        # Skip web-irrelevant metadata silently.
+        if msg.metadata.get("reaction"):
+            return
+        if msg.metadata.get("media_type"):
+            return
+
+        # Send the message.
+        payload: dict[str, Any] = {
+            "type": "message",
+            "content": msg.content,
+        }
+        if is_intermediate:
+            payload["intermediate"] = True
+
+        await self._ws_send(ws, payload)
+
+        # Final message → stop typing.
+        if not is_intermediate and not msg.metadata.get("keep_typing"):
+            await self._ws_send(ws, {"type": "typing", "active": False})
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_index(self, _request: web.Request) -> web.Response:
+        html = (STATIC_DIR / "index.html").read_text()
+        html = html.replace("{{title}}", self.config.title)
+        return web.Response(text=html, content_type="text/html")
+
+    async def _handle_websocket(self, request: web.Request) -> WebSocketResponse:
+        ws = WebSocketResponse()
+        await ws.prepare(request)
+
+        chat_id: str | None = None
+
+        async for raw in ws:
+            if raw.type.name == "TEXT":
+                try:
+                    data = json.loads(raw.data)
+                except json.JSONDecodeError:
+                    await self._ws_send(ws, {"type": "error", "content": "Invalid JSON"})
+                    continue
+
+                msg_type = data.get("type")
+
+                if msg_type == "hello":
+                    chat_id = data.get("chat_id", "")
+                    if chat_id:
+                        self._connections[chat_id] = ws
+                        await self._ws_send(ws, {"type": "hello", "chat_id": chat_id})
+                        logger.debug("Web client connected: {}", chat_id[:8])
+
+                elif msg_type == "message":
+                    content = data.get("content", "").strip()
+                    if chat_id and content:
+                        await self._handle_message(
+                            sender_id=chat_id,
+                            chat_id=chat_id,
+                            content=content,
+                        )
+
+                elif msg_type == "command":
+                    command = data.get("command")
+                    if chat_id and command == "new_chat":
+                        # Remove old mapping; client will re-hello with a new chat_id.
+                        self._connections.pop(chat_id, None)
+                        chat_id = None
+
+            elif raw.type.name == "ERROR":
+                logger.warning("WS error: {}", ws.exception())
+                break
+
+        # Cleanup on disconnect.
+        if chat_id:
+            self._connections.pop(chat_id, None)
+            logger.debug("Web client disconnected: {}", chat_id[:8])
+
+        return ws
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _ws_send(ws: WebSocketResponse, data: dict) -> None:
+        if not ws.closed:
+            await ws.send_json(data)

--- a/ragnarbot/channels/web_static/index.html
+++ b/ragnarbot/channels/web_static/index.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{title}}</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.1/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #0a0a0f;
+    --surface: #12121a;
+    --surface-2: #1a1a25;
+    --border: #2a2a3a;
+    --text: #e0e0e8;
+    --text-dim: #7a7a8a;
+    --accent: #6c5ce7;
+    --accent-dim: #5a4bd6;
+    --user-bg: #1e1e30;
+    --bot-bg: #161620;
+    --scrollbar: #2a2a3a;
+    --scrollbar-hover: #3a3a4a;
+  }
+
+  html, body {
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  #app {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  /* Header */
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+
+  header .title {
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+  }
+
+  header .status {
+    font-size: 11px;
+    color: var(--text-dim);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  header .status .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #555;
+    transition: background 0.3s;
+  }
+
+  header .status .dot.connected { background: #44cc66; }
+
+  #new-chat-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    padding: 5px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  #new-chat-btn:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  /* Messages */
+  #messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  #messages::-webkit-scrollbar { width: 6px; }
+  #messages::-webkit-scrollbar-track { background: transparent; }
+  #messages::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 3px; }
+  #messages::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-hover); }
+
+  .msg {
+    max-width: 85%;
+    padding: 10px 14px;
+    border-radius: 12px;
+    font-size: 14px;
+    line-height: 1.55;
+    word-wrap: break-word;
+    animation: fadeIn 0.15s ease;
+  }
+
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+
+  .msg.user {
+    align-self: flex-end;
+    background: var(--user-bg);
+    border: 1px solid var(--border);
+    border-bottom-right-radius: 4px;
+  }
+
+  .msg.bot {
+    align-self: flex-start;
+    background: var(--bot-bg);
+    border: 1px solid var(--border);
+    border-bottom-left-radius: 4px;
+  }
+
+  .msg.bot.intermediate {
+    opacity: 0.6;
+    border-style: dashed;
+  }
+
+  /* Markdown content */
+  .msg p { margin: 0.4em 0; }
+  .msg p:first-child { margin-top: 0; }
+  .msg p:last-child { margin-bottom: 0; }
+  .msg ul, .msg ol { margin: 0.4em 0; padding-left: 1.4em; }
+  .msg code { background: rgba(255,255,255,0.06); padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+  .msg pre { margin: 0.5em 0; border-radius: 8px; overflow-x: auto; }
+  .msg pre code { display: block; padding: 12px; background: rgba(0,0,0,0.4); font-size: 13px; }
+  .msg blockquote { border-left: 3px solid var(--accent); padding-left: 10px; margin: 0.4em 0; color: var(--text-dim); }
+  .msg a { color: var(--accent); text-decoration: none; }
+  .msg a:hover { text-decoration: underline; }
+  .msg table { border-collapse: collapse; margin: 0.5em 0; font-size: 13px; }
+  .msg th, .msg td { border: 1px solid var(--border); padding: 4px 8px; }
+
+  /* Typing indicator */
+  #typing {
+    display: none;
+    align-self: flex-start;
+    padding: 10px 14px;
+    color: var(--text-dim);
+    font-size: 13px;
+    font-style: italic;
+  }
+
+  #typing.active { display: block; }
+
+  #typing span::after {
+    content: "";
+    animation: dots 1.2s steps(4, end) infinite;
+  }
+
+  @keyframes dots {
+    0%  { content: ""; }
+    25% { content: "."; }
+    50% { content: ".."; }
+    75% { content: "..."; }
+  }
+
+  /* Input */
+  #input-area {
+    padding: 12px 20px 16px;
+    border-top: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+
+  #input-wrap {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+  }
+
+  #input {
+    flex: 1;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px 14px;
+    color: var(--text);
+    font-size: 14px;
+    font-family: inherit;
+    resize: none;
+    min-height: 40px;
+    max-height: 160px;
+    line-height: 1.4;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  #input:focus { border-color: var(--accent); }
+  #input::placeholder { color: var(--text-dim); }
+
+  #send-btn {
+    background: var(--accent);
+    border: none;
+    color: #fff;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 0.15s;
+  }
+
+  #send-btn:hover { background: var(--accent-dim); }
+  #send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  #send-btn svg { width: 18px; height: 18px; }
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <div>
+      <div class="title">{{title}}</div>
+      <div class="status"><span class="dot" id="status-dot"></span><span id="status-text">connecting</span></div>
+    </div>
+    <button id="new-chat-btn">New Chat</button>
+  </header>
+  <div id="messages">
+    <div id="typing"><span>Thinking</span></div>
+  </div>
+  <div id="input-area">
+    <div id="input-wrap">
+      <textarea id="input" rows="1" placeholder="Send a message..." autocomplete="off"></textarea>
+      <button id="send-btn" disabled>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+      </button>
+    </div>
+  </div>
+</div>
+<script>
+(function() {
+  // --- Config ---
+  const WS_URL = `ws://${location.host}/ws`;
+  const STORAGE_KEY = "ragnarbot_chat_id";
+
+  // --- Elements ---
+  const messagesEl = document.getElementById("messages");
+  const typingEl = document.getElementById("typing");
+  const inputEl = document.getElementById("input");
+  const sendBtn = document.getElementById("send-btn");
+  const newChatBtn = document.getElementById("new-chat-btn");
+  const statusDot = document.getElementById("status-dot");
+  const statusText = document.getElementById("status-text");
+
+  // --- State ---
+  let chatId = localStorage.getItem(STORAGE_KEY);
+  if (!chatId) {
+    chatId = crypto.randomUUID();
+    localStorage.setItem(STORAGE_KEY, chatId);
+  }
+
+  let ws = null;
+  let connected = false;
+  let reconnectDelay = 500;
+  const MAX_RECONNECT = 15000;
+
+  // --- Markdown ---
+  marked.setOptions({
+    highlight: function(code, lang) {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(code, { language: lang }).value;
+      }
+      return hljs.highlightAuto(code).value;
+    },
+    breaks: true,
+  });
+
+  // --- WebSocket ---
+  function connect() {
+    setStatus("connecting");
+    ws = new WebSocket(WS_URL);
+
+    ws.onopen = function() {
+      connected = true;
+      reconnectDelay = 500;
+      ws.send(JSON.stringify({ type: "hello", chat_id: chatId }));
+    };
+
+    ws.onmessage = function(e) {
+      const data = JSON.parse(e.data);
+      handleMessage(data);
+    };
+
+    ws.onclose = function() {
+      connected = false;
+      setStatus("disconnected");
+      scheduleReconnect();
+    };
+
+    ws.onerror = function() {
+      ws.close();
+    };
+  }
+
+  function scheduleReconnect() {
+    setTimeout(function() {
+      reconnectDelay = Math.min(reconnectDelay * 1.5, MAX_RECONNECT);
+      connect();
+    }, reconnectDelay);
+  }
+
+  function setStatus(s) {
+    statusText.textContent = s;
+    statusDot.className = "dot" + (s === "connected" ? " connected" : "");
+    sendBtn.disabled = s !== "connected";
+  }
+
+  function handleMessage(data) {
+    switch (data.type) {
+      case "hello":
+        setStatus("connected");
+        break;
+      case "typing":
+        typingEl.classList.toggle("active", data.active);
+        scrollBottom();
+        break;
+      case "message":
+        addMessage("bot", data.content, data.intermediate);
+        break;
+      case "error":
+        addMessage("bot", "Error: " + data.content);
+        break;
+    }
+  }
+
+  // --- Messages ---
+  function addMessage(role, content, intermediate) {
+    // If intermediate, replace previous intermediate message
+    if (role === "bot" && intermediate) {
+      const prev = messagesEl.querySelector(".msg.bot.intermediate");
+      if (prev) prev.remove();
+    }
+    // If final bot message, remove intermediate
+    if (role === "bot" && !intermediate) {
+      const prev = messagesEl.querySelector(".msg.bot.intermediate");
+      if (prev) prev.remove();
+    }
+
+    const div = document.createElement("div");
+    div.className = "msg " + role + (intermediate ? " intermediate" : "");
+
+    if (role === "bot") {
+      div.innerHTML = marked.parse(content);
+      div.querySelectorAll("pre code").forEach(function(block) {
+        hljs.highlightElement(block);
+      });
+    } else {
+      div.textContent = content;
+    }
+
+    messagesEl.insertBefore(div, typingEl);
+    scrollBottom();
+  }
+
+  function scrollBottom() {
+    requestAnimationFrame(function() {
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    });
+  }
+
+  // --- Send ---
+  function sendMessage() {
+    const text = inputEl.value.trim();
+    if (!text || !connected) return;
+
+    addMessage("user", text);
+    ws.send(JSON.stringify({ type: "message", content: text }));
+    inputEl.value = "";
+    autoResize();
+    inputEl.focus();
+  }
+
+  // --- Auto-resize textarea ---
+  function autoResize() {
+    inputEl.style.height = "auto";
+    inputEl.style.height = Math.min(inputEl.scrollHeight, 160) + "px";
+  }
+
+  // --- Events ---
+  inputEl.addEventListener("input", autoResize);
+
+  inputEl.addEventListener("keydown", function(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  sendBtn.addEventListener("click", sendMessage);
+
+  newChatBtn.addEventListener("click", function() {
+    chatId = crypto.randomUUID();
+    localStorage.setItem(STORAGE_KEY, chatId);
+    // Clear messages
+    messagesEl.querySelectorAll(".msg").forEach(function(m) { m.remove(); });
+    typingEl.classList.remove("active");
+    // Notify server
+    if (connected) {
+      ws.send(JSON.stringify({ type: "command", command: "new_chat" }));
+      ws.send(JSON.stringify({ type: "hello", chat_id: chatId }));
+    }
+  });
+
+  // --- Init ---
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -607,6 +607,11 @@ def channels_status():
         tg_config
     )
 
+    # Web
+    web_cfg = config.channels.web
+    web_info = f"http://{web_cfg.host}:{web_cfg.port}" if web_cfg.enabled else "[dim]not configured[/dim]"
+    table.add_row("Web", "✓" if web_cfg.enabled else "✗", web_info)
+
     console.print(table)
 
 

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -13,9 +13,18 @@ class TelegramConfig(BaseModel):
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
 
 
+class WebConfig(BaseModel):
+    """Web channel configuration."""
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8080
+    title: str = "ragnarbot"
+
+
 class ChannelsConfig(BaseModel):
     """Configuration for chat channels."""
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
+    web: WebConfig = Field(default_factory=WebConfig)
 
 
 OAUTH_SUPPORTED_PROVIDERS = {"anthropic"}


### PR DESCRIPTION
## Summary
- New web channel: browser-based chat UI served on `localhost:8080` via aiohttp + WebSocket
- Dark theme, markdown rendering (marked.js), code highlighting (highlight.js), auto-reconnect with exponential backoff
- Configurable title, host, port via `config.json` (`channels.web`)
- Persistent sessions via localStorage, "New Chat" button, typing indicator

## Changes
- **New:** `ragnarbot/channels/web.py` — `WebChannel(BaseChannel)` with aiohttp server + WS handling
- **New:** `ragnarbot/channels/web_static/index.html` — self-contained chat frontend
- **Modified:** `ragnarbot/config/schema.py` — added `WebConfig` (enabled, host, port, title)
- **Modified:** `ragnarbot/channels/manager.py` — web channel initialization
- **Modified:** `ragnarbot/cli/commands.py` — web row in `channels status`
- **Modified:** `pyproject.toml` — aiohttp dependency + static file includes

## Config example
```json
"channels": {
  "web": {
    "enabled": true,
    "title": "Lain"
  }
}
```

## Test plan
- [ ] Enable web channel in config, run `ragnarbot gateway`
- [ ] Open `http://127.0.0.1:8080` — verify chat UI loads
- [ ] Send a message — verify bot responds, typing indicator works
- [ ] Click "New Chat" — verify new session is created
- [ ] Close/reopen tab — verify session persists (same chat_id)
- [ ] Verify Telegram channel continues working in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)