### PR TITLE
feat: add /stop command to interrupt agent processing

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -706,6 +706,8 @@ class AgentLoop:
 
         if not stopped:
             messages.append({"role": "assistant", "content": final_content or ""})
+        else:
+            messages.append({"role": "user", "content": "[Stopped by user]"})
 
         # -- Save new messages to session --
         # User messages come first (one per batch item), then assistant/tool messages.


### PR DESCRIPTION
## Summary

- Add `/stop` bot command that cancels the active LLM call or tool execution mid-response
- Race LLM streaming against stop event — partial responses are discarded cleanly
- Tool execution checks stop before each tool; unexecuted tools get `[Stopped by user]` result
- Record `[Stopped by user]` marker in session history so the bot understands the previous request was intentionally cancelled
- Rework `set_bot_commands` to check-then-update pattern: only writes when stale, clears per-chat `BotCommandScopeChat` overrides that were shadowing the default scope (root cause of commands not appearing in Telegram menu)