### PR TITLE
fix(telegram): typing stops after setting reaction

### DIFF
--- a/ragnarbot/channels/telegram.py
+++ b/ragnarbot/channels/telegram.py
@@ -396,14 +396,7 @@ class TelegramChannel(BaseChannel):
                 )
             return
 
-        # Intermediate message — send text but keep typing active
-        is_intermediate = msg.metadata.get("intermediate", False)
-
-        # Final message — stop typing first (unless keep_typing is set)
-        if not is_intermediate and not msg.metadata.get("keep_typing"):
-            self._stop_typing(chat_id)
-
-        # --- Reaction handling ---
+        # --- Reaction handling (does not interrupt typing) ---
         if msg.metadata.get("reaction"):
             try:
                 from telegram import ReactionTypeEmoji
@@ -415,6 +408,13 @@ class TelegramChannel(BaseChannel):
             except Exception as e:
                 logger.error(f"Error setting reaction: {e}")
             return
+
+        # Intermediate message — send text but keep typing active
+        is_intermediate = msg.metadata.get("intermediate", False)
+
+        # Final message — stop typing first (unless keep_typing is set)
+        if not is_intermediate and not msg.metadata.get("keep_typing"):
+            self._stop_typing(chat_id)
 
         # --- Media sending ---
         media_type = msg.metadata.get("media_type")


### PR DESCRIPTION
## Summary

- Typing indicator was stopping after the bot set a reaction, because reaction messages were processed after the intermediate/final check that calls `_stop_typing()`
- Moved reaction handling block before the typing stop logic so it returns early without interrupting the typing loop