### PR TITLE
fix(config): lower default max_tokens to 16k

### DIFF
--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -41,7 +41,7 @@ class AgentDefaults(BaseModel):
         json_schema_extra={"reload": "warm", "label": "LLM model identifier (provider/model)"},
     )
     max_tokens: int = Field(
-        default=32_000,
+        default=16_000,
         json_schema_extra={"reload": "hot", "label": "Maximum tokens in LLM response"},
     )
     temperature: float = Field(

--- a/tests/test_config_path_utils.py
+++ b/tests/test_config_path_utils.py
@@ -53,7 +53,7 @@ def test_get_by_path_invalid():
 
 def test_get_by_path_camel_case():
     config = Config()
-    assert get_by_path(config, "agents.defaults.maxTokens") == 32_000
+    assert get_by_path(config, "agents.defaults.maxTokens") == 16_000
 
 
 def test_set_by_path_float_coercion():

--- a/uv.lock
+++ b/uv.lock
@@ -1747,7 +1747,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Lowers default `max_tokens` from 32,000 to 16,000 to prevent Anthropic SDK error on fresh installs
- The SDK validates that non-streaming requests won't exceed 10 minutes (`3600 * max_tokens / 128000 > 600`), and 32k triggers this check (~21k threshold)