### PR TITLE
fix(agent): stop typing indicator after reaction-only responses

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -344,6 +344,13 @@ class AgentLoop:
                     response = await self._process_system_message(msg)
                     if response:
                         await self.bus.publish_outbound(response)
+                    else:
+                        await self.bus.publish_outbound(OutboundMessage(
+                            channel=parts[0],
+                            chat_id=parts[1],
+                            content="",
+                            metadata={"stop_typing": True},
+                        ))
                 except Exception as e:
                     logger.error(f"Error processing system message: {e}")
             else:
@@ -351,6 +358,13 @@ class AgentLoop:
                     response = await self._process_batch(batch)
                     if response:
                         await self.bus.publish_outbound(response)
+                    else:
+                        await self.bus.publish_outbound(OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content="",
+                            metadata={"stop_typing": True},
+                        ))
                 except Exception as e:
                     logger.error(f"Error processing message: {e}")
                     await self.bus.publish_outbound(OutboundMessage(

--- a/ragnarbot/channels/telegram.py
+++ b/ragnarbot/channels/telegram.py
@@ -396,6 +396,11 @@ class TelegramChannel(BaseChannel):
                 )
             return
 
+        # Stop typing signal — agent finished without sending a final message
+        if msg.metadata.get("stop_typing"):
+            self._stop_typing(chat_id)
+            return
+
         # --- Reaction handling (does not interrupt typing) ---
         if msg.metadata.get("reaction"):
             try:


### PR DESCRIPTION
## Summary

- When the LLM responds with only a reaction (no text), the typing indicator was never stopped because no outbound message was published to trigger `_stop_typing()`
- Added a `stop_typing` signal through the message bus when `_process_batch()` or `_process_system_message()` returns `None`
- Added handler in `TelegramChannel.send()` to stop the typing loop when the signal is received