### PR TITLE
fix(tools): validate emoji in SetReactionTool

### DIFF
--- a/ragnarbot/agent/context.py
+++ b/ragnarbot/agent/context.py
@@ -146,6 +146,8 @@ Skills with available="false" need dependencies installed first - you can try in
 
     def _load_builtin_telegram(self, user_data: dict) -> str:
         """Load the built-in Telegram context file with user placeholders."""
+        from telegram.constants import ReactionEmoji
+
         file_path = BUILTIN_DIR / "TELEGRAM.md"
         if not file_path.exists():
             return ""
@@ -153,10 +155,12 @@ Skills with available="false" need dependencies installed first - you can try in
         full_name = " ".join(
             filter(None, [user_data.get("first_name"), user_data.get("last_name")])
         )
+        reaction_emojis = " ".join(e.value for e in ReactionEmoji)
         return content.format(
             full_name=full_name or "Unknown",
             username=user_data.get("username") or "N/A",
             user_id=user_data.get("user_id") or "N/A",
+            reaction_emojis=reaction_emojis,
         )
 
     def _load_builtin_cron_isolated(self, cron_ctx: dict) -> str:

--- a/ragnarbot/agent/tools/telegram.py
+++ b/ragnarbot/agent/tools/telegram.py
@@ -2,8 +2,12 @@
 
 from typing import Any, Awaitable, Callable
 
+from telegram.constants import ReactionEmoji
+
 from ragnarbot.agent.tools.base import Tool
 from ragnarbot.bus.events import OutboundMessage
+
+VALID_TELEGRAM_REACTIONS = frozenset(e.value for e in ReactionEmoji)
 
 
 class SendPhotoTool(Tool):
@@ -227,7 +231,7 @@ class SetReactionTool(Tool):
             "properties": {
                 "emoji": {
                     "type": "string",
-                    "description": "A single emoji character to react with",
+                    "description": "A single emoji character to react with. Must be a valid Telegram reaction emoji.",
                 },
             },
             "required": ["emoji"],
@@ -240,6 +244,14 @@ class SetReactionTool(Tool):
             return "Error: Message sending not configured"
         if not self._message_id:
             return "Error: No target message to react to"
+
+        emoji = emoji.strip()
+        if emoji not in VALID_TELEGRAM_REACTIONS:
+            valid_list = " ".join(sorted(VALID_TELEGRAM_REACTIONS))
+            return (
+                f"Error: '{emoji}' is not a valid Telegram reaction. "
+                f"Valid reactions: {valid_list}"
+            )
 
         msg = OutboundMessage(
             channel=self._channel,

--- a/ragnarbot/builtin/TELEGRAM.md
+++ b/ragnarbot/builtin/TELEGRAM.md
@@ -50,4 +50,4 @@ When NOT to react:
 - Do NOT overuse reactions. Most messages do not need one. If in doubt, skip the reaction.
 
 Only one emoji per reaction call. Valid Telegram reaction emojis:
-👍 👎 ❤️ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 🤩 🤮 💩 🙏 👌 🕊 🤡 🥱 🥴 😍 🐳 ❤️‍🔥 🌚 🌭 💯 🤣 ⚡ 🍌 🏆 💔 🤨 😐 🍓 🍾 💋 🖕 😈 😴 😭 🤓 👻 👨‍💻 👀 🎃 🙈 😇 😨 🤝 ✍ 🤗 🫡 🎅 🎄 ☃️ 💅 🤪 🗿 🆒 💘 🙉 🦄 😘 💊 🙊 😎 👾 🤷‍♂ 🤷 🤷‍♀ 😡
+{reaction_emojis}

--- a/tests/test_set_reaction.py
+++ b/tests/test_set_reaction.py
@@ -1,0 +1,51 @@
+"""Tests for SetReactionTool emoji validation."""
+
+import pytest
+
+from ragnarbot.agent.tools.telegram import VALID_TELEGRAM_REACTIONS, SetReactionTool
+
+
+@pytest.fixture
+def tool():
+    """Create a SetReactionTool with a mock callback."""
+    async def noop_callback(msg):
+        pass
+
+    t = SetReactionTool(send_callback=noop_callback)
+    t.set_context(channel="telegram", chat_id="123", message_id=1)
+    return t
+
+
+@pytest.mark.asyncio
+async def test_valid_emoji_succeeds(tool):
+    result = await tool.execute(emoji="👍")
+    assert result == "Reaction 👍 set"
+
+
+@pytest.mark.asyncio
+async def test_invalid_emoji_returns_error(tool):
+    result = await tool.execute(emoji="🎤")
+    assert "not a valid Telegram reaction" in result
+
+
+@pytest.mark.asyncio
+async def test_empty_emoji_returns_error(tool):
+    result = await tool.execute(emoji="")
+    assert "not a valid Telegram reaction" in result
+
+
+@pytest.mark.asyncio
+async def test_whitespace_stripped_valid(tool):
+    result = await tool.execute(emoji=" 👍 ")
+    assert result == "Reaction 👍 set"
+
+
+@pytest.mark.asyncio
+async def test_whitespace_stripped_invalid(tool):
+    result = await tool.execute(emoji="  🎤  ")
+    assert "not a valid Telegram reaction" in result
+
+
+def test_valid_reactions_set_is_populated():
+    assert len(VALID_TELEGRAM_REACTIONS) > 0
+    assert "👍" in VALID_TELEGRAM_REACTIONS


### PR DESCRIPTION
## Summary

- Validate emoji against `telegram.constants.ReactionEmoji` before sending, returning a clear error with valid emojis list on mismatch
- Make TELEGRAM.md emoji list dynamic from the same enum (single source of truth)
- Add unit tests for valid, invalid, empty, and whitespace-padded emoji inputs