### PR TITLE
fix(daemon): enrich PATH at gateway startup for daemon environments

### DIFF
--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -183,6 +183,9 @@ def gateway_main(
 
     console.print(f"{__logo__} Starting ragnarbot gateway on port {port}...")
 
+    from ragnarbot.daemon.resolve import resolve_path
+    resolve_path()
+
     from ragnarbot.config.migration import run_startup_migration
     if not run_startup_migration(console):
         raise typer.Exit(0)

--- a/ragnarbot/daemon/resolve.py
+++ b/ragnarbot/daemon/resolve.py
@@ -1,6 +1,8 @@
-"""Platform detection and executable resolution."""
+"""Platform detection, executable resolution, and PATH enrichment."""
 
+import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -50,3 +52,108 @@ def get_log_dir() -> Path:
     log_dir = Path.home() / ".ragnarbot" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
+
+
+# ---------------------------------------------------------------------------
+# PATH enrichment for daemon environments
+# ---------------------------------------------------------------------------
+
+_WELL_KNOWN_DIRS = [
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    "~/.local/bin",
+    "~/.cargo/bin",
+    "~/.nvm/current/bin",
+    "~/.deno/bin",
+    "~/go/bin",
+    "~/.bun/bin",
+    "/home/linuxbrew/.linuxbrew/bin",
+    "/snap/bin",
+]
+
+
+def _probe_login_shell() -> list[str]:
+    """Run the user's login shell to capture the full PATH."""
+    shell = os.environ.get("SHELL", "/bin/sh")
+    try:
+        result = subprocess.run(
+            [shell, "-l", "-c", "echo $PATH"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [p for p in result.stdout.strip().split(":") if p]
+    except Exception:
+        pass
+    return []
+
+
+def _probe_path_helper() -> list[str]:
+    """Run macOS path_helper to get system-configured paths."""
+    if sys.platform != "darwin":
+        return []
+    helper = "/usr/libexec/path_helper"
+    if not os.path.isfile(helper):
+        return []
+    try:
+        result = subprocess.run(
+            [helper, "-s"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout:
+            # Output format: PATH="..."; export PATH;
+            line = result.stdout.strip()
+            if line.startswith('PATH="') and '"' in line[6:]:
+                raw = line[6:line.index('"', 6)]
+                return [p for p in raw.split(":") if p]
+    except Exception:
+        pass
+    return []
+
+
+def _well_known_dirs() -> list[str]:
+    """Return well-known tool directories that exist on disk."""
+    dirs: list[str] = []
+    for d in _WELL_KNOWN_DIRS:
+        expanded = os.path.expanduser(d)
+        if os.path.isdir(expanded):
+            dirs.append(expanded)
+    return dirs
+
+
+def resolve_path() -> None:
+    """Enrich os.environ["PATH"] with the user's full PATH.
+
+    Runs a 3-step fallback chain. Each step is independent and
+    catches its own errors. The function never raises.
+    """
+    try:
+        current = os.environ.get("PATH", "")
+        current_set = set(current.split(":")) if current else set()
+
+        discovered: list[str] = []
+
+        # 1. Login shell probe
+        for p in _probe_login_shell():
+            if p not in current_set and p not in discovered:
+                discovered.append(p)
+
+        # 2. macOS path_helper
+        for p in _probe_path_helper():
+            if p not in current_set and p not in discovered:
+                discovered.append(p)
+
+        # 3. Well-known directories
+        for p in _well_known_dirs():
+            if p not in current_set and p not in discovered:
+                discovered.append(p)
+
+        if discovered:
+            os.environ["PATH"] = ":".join(discovered) + ":" + current
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

- Add `resolve_path()` to `ragnarbot/daemon/resolve.py` with a 3-step fallback chain (login shell probe, macOS path_helper, well-known dirs) that enriches `os.environ["PATH"]` at gateway startup
- Call `resolve_path()` early in `gateway_main()` so all subprocess call sites (exec, exec_bg, update) inherit the full user PATH
- Add 10 tests covering merging, deduplication, fallthrough, parsing, and resilience

Closes #45