### PR TITLE
feat(config): add Qwen 3.5 Plus model to OpenRouter

### DIFF
--- a/ragnarbot/config/providers.py
+++ b/ragnarbot/config/providers.py
@@ -91,6 +91,11 @@ PROVIDERS = [
                 "description": "Long-context reasoning & coding",
             },
             {
+                "id": "openrouter/qwen/qwen3.5-plus-02-15",
+                "name": "Qwen 3.5 Plus",
+                "description": "Strong multilingual reasoning & coding",
+            },
+            {
                 "id": "openrouter/anthropic/claude-opus-4.6",
                 "name": "Claude Opus 4.6",
                 "description": "Most intelligent — via OpenRouter",


### PR DESCRIPTION
## Summary
- Add `qwen/qwen3.5-plus-02-15` to OpenRouter provider models
- Vision supported, all providers available