### PR TITLE
feat(cron): add `after` param and past-time rejection

### DIFF
--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -136,9 +136,14 @@ All scheduled work goes through the `cron` tool: one-shot reminders, recurring t
 
 ### Schedule Types
 
-**One-shot** (`at`) — runs once at a specific time. Auto-deletes after execution. Logs persist.
+**One-shot absolute** (`at`) — runs once at a specific time. Auto-deletes after execution. Logs persist.
 ```
 cron(action="add", message="Call John", at="2026-02-12T15:00:00", mode="session")
+```
+
+**One-shot relative** (`after`) — runs once after N seconds from now. Auto-deletes after execution. Simpler than `at` when you just need "in X minutes".
+```
+cron(action="add", message="Retry the generation", after=300, mode="session")
 ```
 
 **Interval** (`every_seconds`) — runs every N seconds, persists.
@@ -173,6 +178,16 @@ Use isolated when:
 - Tasks requiring tool use (fetching, commands, reports) → isolated
 - When in doubt → isolated
 
+**Quick selection guide:**
+
+| Situation | Mode | Schedule |
+|---|---|---|
+| Retry/continue something from chat | `session` | `after` |
+| Reminder at specific time | `session` | `at` |
+| Self-contained fetch/report | `isolated` | `cron_expr` or `every_seconds` |
+
+If the task is a continuation or retry of something already discussed in the current chat, always use `session` mode with `after`.
+
 ### When to Ask the User
 
 Do NOT ask about mode or schedule type when the intent is clear. The user shouldn't need to know about "isolated" or "session" — that's an implementation detail.
@@ -182,6 +197,8 @@ Do NOT ask about mode or schedule type when the intent is clear. The user should
 - "Check HN every hour and send me top stories" → recurring, isolated. Done.
 - "Every morning at 9, summarize my emails" → recurring, isolated. Done.
 - "Ping me every 30 minutes to drink water" → recurring, session. Done.
+- "Try again in 5 minutes" → `after=300`, session. Done.
+- "Retry in 10 minutes" → `after=600`, session. Done.
 
 **Ask** when:
 - The user says "schedule something" but you can't tell if it's one-shot or recurring

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -69,13 +69,14 @@ The subagent gets its own tool access and reports back when done. Give it a clea
 
 ### cron
 Schedule and manage tasks. Actions:
-- `add` — create a job. Requires `message` and one of `at`, `every_seconds`, or `cron_expr`. Optional: `name`, `mode`.
+- `add` — create a job. Requires `message` and one of `at`, `after`, `every_seconds`, or `cron_expr`. Optional: `name`, `mode`.
 - `list` — show all scheduled jobs with mode, schedule, and status.
 - `update` — modify a job. Requires `job_id`. Supports: `name`, `message`, `mode`, `enabled`, `every_seconds`, `cron_expr`.
 - `remove` — delete a job by `job_id`.
 
 **Schedule types:**
-- `at` — ISO datetime (e.g. `"2026-02-12T15:00:00"`). One-shot: runs once and **auto-deletes**. Logs persist.
+- `at` — ISO datetime (e.g. `"2026-02-12T15:00:00"`). One-shot: runs once and **auto-deletes**. Logs persist. Rejects past times with an error.
+- `after` — seconds from now (e.g. `300` = in 5 minutes). One-shot: runs once and **auto-deletes**. Minimum 10 seconds. Simpler than `at` for relative delays.
 - `every_seconds` — interval in seconds (recurring).
 - `cron_expr` — cron expression like `"0 9 * * *"` (recurring). Uses the user's local timezone automatically.
 
@@ -102,7 +103,10 @@ Capture the final output of an isolated cron job or heartbeat check. Available d
 | User says | Parameters |
 |---|---|
 | at 3pm today | `at="2026-02-12T15:00:00"` |
-| in 2 hours | `at` with computed ISO datetime |
+| in 2 minutes | `after=120` |
+| in 5 minutes | `after=300` |
+| in 1 hour | `after=3600` |
+| in 2 hours | `after=7200` |
 | every 20 minutes | `every_seconds=1200` |
 | every hour | `every_seconds=3600` |
 | every day at 8am | `cron_expr="0 8 * * *"` |

--- a/tests/test_cron_tool.py
+++ b/tests/test_cron_tool.py
@@ -1,0 +1,87 @@
+"""Tests for CronTool — after param, past-time rejection, schema."""
+
+import datetime
+from datetime import timedelta
+
+import pytest
+
+from ragnarbot.agent.tools.cron import CronTool
+from ragnarbot.cron.service import CronService
+
+
+@pytest.fixture
+def cron_tool(tmp_path):
+    """Create a CronTool backed by a real CronService in a temp directory."""
+    store_path = tmp_path / "cron.json"
+    service = CronService(store_path=store_path)
+    tool = CronTool(service)
+    tool.set_context(channel="test", chat_id="123")
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_after_creates_one_shot_job(cron_tool):
+    """after=300 should create a one-shot job ~300s in the future."""
+    before = datetime.datetime.now()
+    result = await cron_tool.execute(action="add", message="retry task", after=300)
+    after = datetime.datetime.now()
+
+    assert "Created job" in result
+
+    # Verify the job was actually created with correct timing
+    jobs = cron_tool._cron.list_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.schedule.kind == "at"
+
+    expected_min = int((before + timedelta(seconds=300)).timestamp() * 1000)
+    expected_max = int((after + timedelta(seconds=300)).timestamp() * 1000)
+    assert expected_min <= job.schedule.at_ms <= expected_max
+
+
+@pytest.mark.asyncio
+async def test_after_below_minimum_returns_error(cron_tool):
+    """after=5 should be rejected (minimum is 10)."""
+    result = await cron_tool.execute(action="add", message="too soon", after=5)
+    assert "Error" in result
+    assert "at least 10" in result
+
+    # No job should be created
+    assert len(cron_tool._cron.list_jobs()) == 0
+
+
+@pytest.mark.asyncio
+async def test_at_past_datetime_returns_error(cron_tool):
+    """Scheduling with 'at' in the past should return an error."""
+    past = (datetime.datetime.now() - timedelta(hours=1)).isoformat()
+    result = await cron_tool.execute(action="add", message="too late", at=past)
+    assert "Error" in result
+    assert "past" in result
+
+    assert len(cron_tool._cron.list_jobs()) == 0
+
+
+@pytest.mark.asyncio
+async def test_at_future_datetime_succeeds(cron_tool):
+    """Scheduling with 'at' in the future should work."""
+    future = (datetime.datetime.now() + timedelta(hours=1)).isoformat()
+    result = await cron_tool.execute(action="add", message="future task", at=future)
+    assert "Created job" in result
+    assert len(cron_tool._cron.list_jobs()) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_schedule_params_mentions_after(cron_tool):
+    """Error when no schedule param is given should mention 'after'."""
+    result = await cron_tool.execute(action="add", message="no schedule")
+    assert "Error" in result
+    assert "after" in result
+
+
+def test_schema_includes_after_property(cron_tool):
+    """The tool schema should include the 'after' property."""
+    schema = cron_tool.parameters
+    assert "after" in schema["properties"]
+    after_schema = schema["properties"]["after"]
+    assert after_schema["type"] == "integer"
+    assert after_schema["minimum"] == 10


### PR DESCRIPTION
## Summary

- Add `after` integer parameter for relative one-shot scheduling (e.g. `after=300` for "in 5 minutes"), converts to `kind="at"` schedule internally
- Reject `at` datetimes that are in the past with a clear error suggesting `after` instead
- Update AGENTS.md with `after` examples, mode selection guide table, and "just do it" entries
- Update BUILTIN_TOOLS.md with `after` schedule type docs and time expression reference

Closes #55