### PR TITLE
feat(agent): include file path marker for user-sent photos

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -707,6 +707,17 @@ class AgentLoop:
                     media_refs.append({"type": "photo", "filename": filename})
                     reply_to["has_photo"] = True
 
+            # Inject photo path markers into content
+            if self.media_manager:
+                photo_paths = [
+                    str(self.media_manager.get_photo_path(session.key, ref["filename"]))
+                    for ref in media_refs
+                    if ref["type"] == "photo"
+                ]
+                if photo_paths:
+                    markers = "\n".join(f"[photo saved: {p}]" for p in photo_paths)
+                    m.content = f"{m.content}\n{markers}" if m.content else markers
+
             # Build prefix tags (timestamp only on the first message in the batch)
             is_first = m is batch[0]
             current_meta: dict = {}


### PR DESCRIPTION
## Summary

- After photos are saved to disk in `_process_batch`, inject a `[photo saved: /path]` marker into the message content
- The agent can now reference user-sent photos programmatically (e.g. pass to generation tools as reference images)
- Mirrors the existing `[file available: ...]` pattern used for documents

Closes #56