### PR TITLE
feat(config): add Claude Sonnet 4.6 model support

### DIFF
--- a/ragnarbot/config/providers.py
+++ b/ragnarbot/config/providers.py
@@ -15,9 +15,14 @@ PROVIDERS = [
                 "description": "Most intelligent — agents & coding",
             },
             {
+                "id": "anthropic/claude-sonnet-4-6",
+                "name": "Claude Sonnet 4.6",
+                "description": "Best speed/intelligence balance",
+            },
+            {
                 "id": "anthropic/claude-sonnet-4-5",
                 "name": "Claude Sonnet 4.5",
-                "description": "Best speed/intelligence balance",
+                "description": "Previous gen — still capable & affordable",
             },
             {
                 "id": "anthropic/claude-haiku-4-5",
@@ -99,6 +104,11 @@ PROVIDERS = [
                 "id": "openrouter/anthropic/claude-opus-4.6",
                 "name": "Claude Opus 4.6",
                 "description": "Most intelligent — via OpenRouter",
+            },
+            {
+                "id": "openrouter/anthropic/claude-sonnet-4.6",
+                "name": "Claude Sonnet 4.6",
+                "description": "Best speed/intelligence balance — via OpenRouter",
             },
             {
                 "id": "openrouter/google/gemini-3-flash-preview",

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -140,7 +140,7 @@ class TestOnboardingFlow:
         mock_save_config, mock_save_creds = self._run_with_keys(keys, tmp_path)
 
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "anthropic/claude-sonnet-4-5"
+        assert config.agents.defaults.model == "anthropic/claude-sonnet-4-6"
         assert config.agents.defaults.auth_method == "oauth"
 
         creds = mock_save_creds.call_args[0][0]

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -47,7 +47,7 @@ def test_get_provider_not_found():
 
 def test_get_models_returns_list():
     models = get_models("anthropic")
-    assert len(models) == 3
+    assert len(models) == 4
     assert models[0]["id"] == "anthropic/claude-opus-4-6"
 
 


### PR DESCRIPTION
## Summary
- Added `claude-sonnet-4-6` to Anthropic and OpenRouter provider registries
- Kept Sonnet 4.5 as a fallback option