### PR TITLE
docs(secrets): document secrets.extra for custom API keys

### DIFF
--- a/ragnarbot/agent/tools/secrets_helpers.py
+++ b/ragnarbot/agent/tools/secrets_helpers.py
@@ -115,6 +115,11 @@ def secrets_schema(creds: Credentials, filter_path: str | None = None) -> str:
         status = "[set \u2713]" if creds.extra[key] else "[not set \u2717]"
         lines.append(f"{full} {status}")
 
+    # Static hint so the feature is discoverable even when extra is empty
+    hint = "secrets.extra.<name>: str [warm] — arbitrary credentials (set any key)"
+    if not filter_path or hint.startswith(filter_path) or "secrets.extra".startswith(filter_path):
+        lines.append(hint)
+
     if not lines:
         return f"No secrets matching '{filter_path}'" if filter_path else "No secrets found"
     return "\n".join(lines)

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -333,6 +333,10 @@ You have tools to inspect and change your own configuration, manage secrets, res
 - Use `secrets.*` paths in the config tool to view and set API keys and tokens.
 - **`get` on a secret returns the actual unmasked value.** This is the only way to see a secret's real value. Only do this when the user very explicitly asks to see their key (e.g. "show me my Anthropic API key"). Do not retrieve secret values on your own initiative — not for debugging, not for verification, not for any reason unless the user directly asks.
 - When a user gives you an API key to set, set it via `config set` with the `secrets.*` path and confirm it was saved.
+- For API keys and tokens not covered by the built-in fields (providers, services, channels), use `secrets.extra.<name>`:
+  - `config set secrets.extra.notion_token ntn_xxx...` — store a custom credential
+  - `config get secrets.extra.notion_token` — retrieve it
+  - Any string key is accepted. Use descriptive names (e.g. `github_token`, `slack_webhook_url`).
 
 ---
 

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -184,6 +184,8 @@ Fields have reload levels:
 - **warm** — saved to disk, requires `restart` tool to apply (e.g. model, telegram settings, gateway port).
 - **cold** — saved to disk, requires full re-onboard to apply (e.g. workspace path).
 
+For storing arbitrary API keys not covered by built-in fields, use `secrets.extra.<name>` paths (e.g. `config set secrets.extra.notion_token ntn_xxx`).
+
 ### restart
 Schedule a graceful gateway restart. The restart happens after the current response is fully sent. Use after changing "warm" config values that need a restart to apply.
 


### PR DESCRIPTION
## Summary

- Added `secrets.extra.<name>` documentation to the Operations Manual (AGENTS.md) with set/get examples
- Added a static hint line in `secrets_schema()` so `config schema` always shows `secrets.extra.<name>` even when the dict is empty
- Added a note to the Built-in Tools reference (BUILTIN_TOOLS.md) under the config tool section

Closes #60