### PR TITLE
fix(exec): narrow safety guard patterns to prevent false positives

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -164,6 +164,7 @@ class AgentLoop:
             working_dir=str(self.workspace),
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.exec_config.restrict_to_workspace,
+            safety_guard=self.exec_config.safety_guard,
         ))
         
         # Web tools
@@ -1707,6 +1708,7 @@ class AgentLoop:
             working_dir=str(self.workspace),
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.exec_config.restrict_to_workspace,
+            safety_guard=self.exec_config.safety_guard,
         ))
 
         # Web

--- a/ragnarbot/agent/subagent.py
+++ b/ragnarbot/agent/subagent.py
@@ -118,6 +118,7 @@ class SubagentManager:
                 working_dir=str(self.workspace),
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.exec_config.restrict_to_workspace,
+                safety_guard=self.exec_config.safety_guard,
             ))
             tools.register(WebSearchTool(engine=self.search_engine, api_key=self.brave_api_key))
             tools.register(WebFetchTool())

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -21,7 +21,7 @@ List directory contents. Use to explore project structure or check what files ex
 ### exec
 Execute a shell command. Returns stdout, stderr, and exit code.
 - Has a timeout (commands that run too long are killed).
-- Destructive commands (rm -rf, format, dd, etc.) are blocked by safety guards.
+- Destructive commands (rm -rf, format, dd, etc.) are blocked by safety guards (can be disabled via `tools.exec.safetyGuard: false` in config).
 - Provide `working_dir` when the command must run in a specific directory.
 - For long-running processes, warn the user about potential timeout.
 

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -159,6 +159,10 @@ class ExecToolConfig(BaseModel):
         default=False,
         json_schema_extra={"reload": "hot", "label": "Block commands outside workspace"},
     )
+    safety_guard: bool = Field(
+        default=True,
+        json_schema_extra={"reload": "hot", "label": "Enable shell command safety guard"},
+    )
 
 
 class BrowserConfig(BaseModel):

--- a/tests/test_shell_guard.py
+++ b/tests/test_shell_guard.py
@@ -1,0 +1,121 @@
+"""Tests for ExecTool safety guard."""
+
+import pytest
+
+from ragnarbot.agent.tools.shell import ExecTool
+
+
+class TestShellGuardPatterns:
+    """Test the _guard_command deny patterns on ExecTool."""
+
+    def _guard(self, command: str) -> str | None:
+        tool = ExecTool()
+        return tool._guard_command(command, "/tmp")
+
+    # -- format / mkfs / diskpart -------------------------------------------
+
+    def test_blocks_format_command(self):
+        assert self._guard("format C:") is not None
+
+    def test_blocks_sudo_format(self):
+        assert self._guard("sudo format C:") is not None
+
+    def test_blocks_mkfs(self):
+        assert self._guard("mkfs.ext4 /dev/sda1") is not None
+        assert self._guard("sudo mkfs /dev/sdb") is not None
+
+    def test_blocks_format_after_separator(self):
+        assert self._guard("echo ok; format C:") is not None
+        assert self._guard("echo ok && format C:") is not None
+        assert self._guard("echo ok | format") is not None
+
+    def test_allows_format_in_flags(self):
+        """Issue #66: --output-format and similar flags must not be blocked."""
+        assert self._guard("claude -p 'hello' --output-format json") is None
+        assert self._guard("claude -p 'hello' --output-format text") is None
+        assert self._guard("git log --format='%H %s'") is None
+        assert self._guard("docker inspect --format '{{.State.Status}}'") is None
+        assert self._guard("cargo build --message-format json") is None
+        assert self._guard("pytest --log-format='%(message)s'") is None
+        assert self._guard("echo '--output-format json'") is None
+
+    # -- shutdown / reboot / poweroff ----------------------------------------
+
+    def test_blocks_shutdown_command(self):
+        assert self._guard("shutdown now") is not None
+        assert self._guard("shutdown -h now") is not None
+
+    def test_blocks_sudo_shutdown(self):
+        assert self._guard("sudo shutdown -h now") is not None
+        assert self._guard("sudo reboot") is not None
+
+    def test_blocks_reboot_command(self):
+        assert self._guard("reboot") is not None
+
+    def test_blocks_poweroff_command(self):
+        assert self._guard("poweroff") is not None
+
+    def test_blocks_power_after_separator(self):
+        assert self._guard("echo ok; shutdown now") is not None
+        assert self._guard("echo ok && reboot") is not None
+        assert self._guard("true | poweroff") is not None
+
+    def test_allows_reboot_as_argument(self):
+        """These are read-only diagnostic commands that should not be blocked."""
+        assert self._guard("last reboot") is None
+        assert self._guard("grep shutdown /var/log/syslog") is None
+        assert self._guard("grep reboot /var/log/messages") is None
+        assert self._guard("journalctl | grep reboot") is None
+        assert self._guard("systemctl status reboot.target") is None
+        assert self._guard("echo 'system shutdown required'") is None
+
+    # -- rm patterns ---------------------------------------------------------
+
+    def test_blocks_rm_rf(self):
+        assert self._guard("rm -rf /") is not None
+        assert self._guard("rm -r /tmp/dir") is not None
+        assert self._guard("rm -f file.txt") is not None
+
+    def test_allows_safe_rm(self):
+        assert self._guard("rm file.txt") is None
+
+    # -- dd pattern ----------------------------------------------------------
+
+    def test_blocks_dd(self):
+        assert self._guard("dd if=/dev/zero of=/dev/sda") is not None
+
+    def test_allows_non_dd_commands(self):
+        assert self._guard("echo hello") is None
+
+    # -- fork bomb -----------------------------------------------------------
+
+    def test_blocks_fork_bomb(self):
+        assert self._guard(":(){ :|:& };:") is not None
+
+    # -- general safe commands -----------------------------------------------
+
+    def test_allows_common_safe_commands(self):
+        assert self._guard("ls -la") is None
+        assert self._guard("echo hello") is None
+        assert self._guard("python script.py") is None
+        assert self._guard("cat file.txt") is None
+        assert self._guard("grep pattern file.txt") is None
+        assert self._guard("pip install package") is None
+        assert self._guard("git status") is None
+        assert self._guard("uv run pytest") is None
+
+
+class TestSafetyGuardToggle:
+    """Test the safety_guard=False config option."""
+
+    @pytest.mark.asyncio
+    async def test_safety_guard_disabled_allows_dangerous(self):
+        tool = ExecTool(safety_guard=False)
+        result = await tool.execute("echo 'rm -rf /' test")
+        assert "blocked" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_safety_guard_enabled_blocks_dangerous(self):
+        tool = ExecTool(safety_guard=True)
+        result = await tool.execute("rm -rf /")
+        assert "blocked" in result.lower()


### PR DESCRIPTION
## Summary

- Replaced overly-broad `\b` word-boundary deny patterns for `format/mkfs/diskpart` and `shutdown/reboot/poweroff` with command-position matching — only fires when the keyword is an actual command, not part of a flag or argument
- Added `tools.exec.safetyGuard` config toggle (hot-reloadable) to disable the safety guard entirely

Closes #66