### PR TITLE
fix(file_read): lower image size limit to 5 MB and return actionable error

### DIFF
--- a/ragnarbot/agent/tools/filesystem.py
+++ b/ragnarbot/agent/tools/filesystem.py
@@ -8,7 +8,7 @@ from typing import Any
 from ragnarbot.agent.tools.base import Tool
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
-MAX_IMAGE_SIZE = 20 * 1024 * 1024  # 20 MB (Anthropic limit)
+MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5 MB (Anthropic API limit for base64 images)
 
 
 class ReadFileTool(Tool):
@@ -74,7 +74,13 @@ class ReadFileTool(Tool):
         size = file_path.stat().st_size
         if size > MAX_IMAGE_SIZE:
             size_mb = size / (1024 * 1024)
-            return f"Error: Image too large ({size_mb:.1f} MB). Maximum is 20 MB."
+            limit_mb = MAX_IMAGE_SIZE / (1024 * 1024)
+            return (
+                f"Error: Image file exceeds {limit_mb:.0f} MB size limit "
+                f"(actual: {size_mb:.1f} MB). The image cannot be displayed inline. "
+                f"Use shell tools to resize or compress it, "
+                f"or ask the user to provide a smaller version."
+            )
 
         mime, _ = mimetypes.guess_type(str(file_path))
         mime = mime or "image/jpeg"

--- a/tests/test_visual_file_read.py
+++ b/tests/test_visual_file_read.py
@@ -84,14 +84,15 @@ class TestReadFileToolImages:
     @pytest.mark.asyncio
     async def test_large_image_rejected(self, tmp_path):
         img = tmp_path / "huge.jpg"
-        # Write a file just over 20 MB
+        # Write a file just over the size limit
         img.write_bytes(b"\xff\xd8\xff" + b"\x00" * (MAX_IMAGE_SIZE + 1))
 
         tool = ReadFileTool()
         result = await tool.execute(path=str(img))
 
         assert isinstance(result, str)
-        assert "too large" in result.lower()
+        assert "exceeds" in result.lower()
+        assert "size limit" in result.lower()
 
     @pytest.mark.asyncio
     async def test_missing_file_error(self):


### PR DESCRIPTION
## Summary

- Lowered `MAX_IMAGE_SIZE` from 20 MB to 5 MB to match the Anthropic API limit for base64 images
- Updated error message to be actionable — the agent now gets a clear explanation and suggestions (resize, compress, or ask the user)
- Updated test assertions for the new error wording

Closes #65