### PR TITLE
feat: add event-driven webhook hooks system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "python-telegram-bot>=21.0",
     "ddgs>=9.0.0",
     "patchright>=1.40.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.optional-dependencies]
@@ -58,6 +59,7 @@ include = [
     "ragnarbot/**/*.py",
     "ragnarbot/skills/**/*.md",
     "ragnarbot/skills/**/*.sh",
+    "ragnarbot/builtin/**/*.md",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/ragnarbot/agent/context.py
+++ b/ragnarbot/agent/context.py
@@ -82,6 +82,13 @@ class ContextBuilder:
             if hb_isolated:
                 parts.append(hb_isolated)
 
+        # 3d. Hook isolated mode (conditional)
+        if session_metadata and session_metadata.get("hook_isolated"):
+            hook_ctx = session_metadata["hook_isolated"]
+            hook_isolated = self._load_builtin_hook_isolated(hook_ctx)
+            if hook_isolated:
+                parts.append(hook_isolated)
+
         # 4. Bootstrap protocol (first-run only, self-deleting)
         bootstrap_protocol = self.workspace / "BOOTSTRAP.md"
         if bootstrap_protocol.exists():
@@ -216,6 +223,22 @@ Use `agent_spawn` to start a task with a specific agent type, or omit the agent 
         return content.format(
             current_time=_time.strftime("%Y-%m-%d %H:%M:%S %Z"),
             tasks_summary=hb_ctx.get("tasks_summary", "No tasks."),
+            workspace_path=str(self.workspace.expanduser().resolve()),
+        )
+
+    def _load_builtin_hook_isolated(self, hook_ctx: dict) -> str:
+        """Load the hook isolated mode system prompt with placeholders."""
+        import time as _time
+        file_path = BUILTIN_DIR / "HOOK_ISOLATED.md"
+        if not file_path.exists():
+            return ""
+        content = file_path.read_text(encoding="utf-8")
+        return content.format(
+            hook_name=hook_ctx.get("hook_name", "Unknown"),
+            hook_mode=hook_ctx.get("hook_mode", "alert"),
+            current_time=_time.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            instructions=hook_ctx.get("instructions", ""),
+            payload=hook_ctx.get("payload", ""),
             workspace_path=str(self.workspace.expanduser().resolve()),
         )
 

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -27,11 +27,11 @@ from ragnarbot.agent.tools.background import (
 )
 from ragnarbot.agent.tools.config_tool import ConfigTool
 from ragnarbot.agent.tools.cron import CronTool
-from ragnarbot.agent.tools.hook import HookTool
 from ragnarbot.agent.tools.deliver_result import DeliverResultTool
 from ragnarbot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from ragnarbot.agent.tools.heartbeat import HeartbeatTool, parse_blocks
 from ragnarbot.agent.tools.heartbeat_done import HeartbeatDoneTool
+from ragnarbot.agent.tools.hook import HookTool
 from ragnarbot.agent.tools.media import DownloadFileTool
 from ragnarbot.agent.tools.registry import ToolRegistry
 from ragnarbot.agent.tools.restart import RestartTool
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from ragnarbot.agent.agents_loader import AgentDefinition
     from ragnarbot.config.schema import BrowserConfig, ExecToolConfig, FallbackConfig
     from ragnarbot.cron.service import CronService
+    from ragnarbot.hooks.service import HookService
 
 
 @dataclass

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -27,6 +27,7 @@ from ragnarbot.agent.tools.background import (
 )
 from ragnarbot.agent.tools.config_tool import ConfigTool
 from ragnarbot.agent.tools.cron import CronTool
+from ragnarbot.agent.tools.hook import HookTool
 from ragnarbot.agent.tools.deliver_result import DeliverResultTool
 from ragnarbot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from ragnarbot.agent.tools.heartbeat import HeartbeatTool, parse_blocks
@@ -137,6 +138,7 @@ class AgentLoop:
         search_engine: str = "brave",
         exec_config: "ExecToolConfig | None" = None,
         cron_service: "CronService | None" = None,
+        hook_service: "HookService | None" = None,
         stream_steps: bool = False,
         media_manager: MediaManager | None = None,
         debounce_seconds: float = 0.5,
@@ -163,6 +165,7 @@ class AgentLoop:
         self.search_engine = search_engine
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
+        self.hook_service = hook_service
         self.stream_steps = stream_steps
         self.media_manager = media_manager
         self.debounce_seconds = debounce_seconds
@@ -275,6 +278,10 @@ class AgentLoop:
         # Cron tool (for scheduling)
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
+
+        # Hook tool (for webhooks)
+        if self.hook_service:
+            self.tools.register(HookTool(self.hook_service))
 
         # Heartbeat tool (for managing periodic tasks)
         self.tools.register(HeartbeatTool(workspace=self.workspace))
@@ -1225,6 +1232,10 @@ class AgentLoop:
         cron_tool = self.tools.get("cron")
         if isinstance(cron_tool, CronTool):
             cron_tool.set_context(msg.channel, msg.chat_id)
+
+        hook_tool = self.tools.get("hook")
+        if isinstance(hook_tool, HookTool):
+            hook_tool.set_context(msg.channel, msg.chat_id)
 
         exec_bg_tool = self.tools.get("exec_bg")
         if isinstance(exec_bg_tool, ExecBgTool):
@@ -2271,6 +2282,10 @@ class AgentLoop:
         if isinstance(cron_tool, CronTool):
             cron_tool.set_context(origin_channel, origin_chat_id)
 
+        hook_tool = self.tools.get("hook")
+        if isinstance(hook_tool, HookTool):
+            hook_tool.set_context(origin_channel, origin_chat_id)
+
         exec_bg_tool = self.tools.get("exec_bg")
         if isinstance(exec_bg_tool, ExecBgTool):
             exec_bg_tool.set_context(origin_channel, origin_chat_id)
@@ -2715,6 +2730,12 @@ class AgentLoop:
             cron_tool.set_context(channel, chat_id)
             reg.register(cron_tool)
 
+        # Hooks
+        if self.hook_service:
+            hook_tool = HookTool(self.hook_service)
+            hook_tool.set_context(channel, chat_id)
+            reg.register(hook_tool)
+
         # Background execution
         bg = BackgroundProcessManager(
             bus=self.bus, workspace=self.workspace, exec_config=self.exec_config,
@@ -2960,6 +2981,98 @@ class AgentLoop:
                     return deliver_tool.result
             else:
                 # Agent finished with text — use as fallback result
+                await self._record_fallback_batch(
+                    batch_used_fallback, channel, chat_id,
+                )
+                return response.content or None
+
+    async def process_hook_isolated(
+        self,
+        hook_name: str,
+        instructions: str,
+        payload: str,
+        mode: str,
+        channel: str,
+        chat_id: str,
+    ) -> str | None:
+        """Run an isolated hook trigger — fresh context, no session history.
+
+        Returns the result string (from deliver_result or final LLM text),
+        or None if the agent produced no output.
+        """
+        tools, deliver_tool = self._build_isolated_tool_registry(channel, chat_id)
+
+        session_metadata = {
+            "hook_isolated": {
+                "hook_name": hook_name,
+                "hook_mode": mode,
+                "instructions": instructions,
+                "payload": payload,
+            },
+        }
+
+        messages = self.context.build_messages(
+            history=[],
+            current_message=f"Process this hook trigger for '{hook_name}'.",
+            channel=channel,
+            chat_id=chat_id,
+            session_metadata=session_metadata,
+        )
+
+        chat_kwargs: dict[str, Any] = {
+            "messages": None,
+            "tools": None,
+        }
+
+        batch_used_fallback = False
+        while True:
+            tools_defs = tools.get_definitions()
+            api_messages = [
+                {k: v for k, v in m.items() if k != "_ts"} for m in messages
+            ]
+            chat_kwargs["messages"] = api_messages
+            chat_kwargs["tools"] = tools_defs
+            response, used_fallback, _ = await self._chat_with_fallback(
+                None,
+                **chat_kwargs,
+            )
+            if used_fallback:
+                batch_used_fallback = True
+
+            if response is None:
+                await self._record_fallback_batch(batch_used_fallback, channel, chat_id)
+                return None
+
+            if response.has_tool_calls:
+                tool_call_dicts = []
+                for tc in response.tool_calls:
+                    _tc = {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.arguments),
+                        },
+                    }
+                    if tc.metadata:
+                        _tc["metadata"] = tc.metadata
+                    tool_call_dicts.append(_tc)
+                messages = self.context.add_assistant_message(
+                    messages, response.content, tool_call_dicts,
+                )
+
+                for tc in response.tool_calls:
+                    result = await tools.execute(tc.name, tc.arguments)
+                    messages = self.context.add_tool_result(
+                        messages, tc.id, tc.name, result,
+                    )
+
+                if deliver_tool.result is not None:
+                    await self._record_fallback_batch(
+                        batch_used_fallback, channel, chat_id,
+                    )
+                    return deliver_tool.result
+            else:
                 await self._record_fallback_batch(
                     batch_used_fallback, channel, chat_id,
                 )

--- a/ragnarbot/agent/tools/hook.py
+++ b/ragnarbot/agent/tools/hook.py
@@ -1,0 +1,175 @@
+"""Hook tool for creating and managing webhook hooks."""
+
+from typing import Any
+
+from ragnarbot.agent.tools.base import Tool
+from ragnarbot.hooks.service import HookService
+
+
+class HookTool(Tool):
+    """Tool to create and manage webhook hooks."""
+
+    def __init__(self, hook_service: HookService):
+        self._hooks = hook_service
+        self._channel = ""
+        self._chat_id = ""
+
+    def set_context(self, channel: str, chat_id: str) -> None:
+        """Set the current session context for delivery."""
+        self._channel = channel
+        self._chat_id = chat_id
+
+    @property
+    def name(self) -> str:
+        return "hook"
+
+    @property
+    def description(self) -> str:
+        return "Create and manage webhook hooks. Actions: create, list, update, delete, history."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["create", "list", "update", "delete", "history"],
+                    "description": "Action to perform",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Hook name (for create/update)",
+                },
+                "instructions": {
+                    "type": "string",
+                    "description": (
+                        "Instructions for the isolated handler session. "
+                        "Describes what to do with the incoming payload. (for create/update)"
+                    ),
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["alert", "silent"],
+                    "description": (
+                        "Delivery mode: 'alert' (deliver to chat, default) "
+                        "or 'silent' (log only, no delivery unless instructions say so)"
+                    ),
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Hook ID (for update/delete/history)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Number of history entries to return (default 10)",
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(
+        self,
+        action: str,
+        name: str = "",
+        instructions: str = "",
+        mode: str = "",
+        id: str = "",
+        limit: int = 10,
+        **kwargs: Any,
+    ) -> str:
+        if action == "create":
+            return self._create(name, instructions, mode)
+        elif action == "list":
+            return self._list()
+        elif action == "update":
+            return self._update(id, name, instructions, mode)
+        elif action == "delete":
+            return self._delete(id)
+        elif action == "history":
+            return self._history(id, limit)
+        return f"Unknown action: {action}"
+
+    def _create(self, name: str, instructions: str, mode: str) -> str:
+        if not name:
+            return "Error: name is required for create"
+        if not instructions:
+            return "Error: instructions is required for create"
+        if not self._channel or not self._chat_id:
+            return "Error: no session context (channel/chat_id)"
+
+        hook_mode = mode if mode in ("alert", "silent") else "alert"
+        hook = self._hooks.add_hook(
+            name=name,
+            instructions=instructions,
+            mode=hook_mode,
+            channel=self._channel,
+            to=self._chat_id,
+        )
+
+        return (
+            f"Created hook '{hook.name}'\n"
+            f"- ID/Secret: {hook.id}\n"
+            f"- URL: /hooks/{hook.id}\n"
+            f"- Mode: {hook.mode}\n\n"
+            f"Trigger with:\n"
+            f"  curl -X POST http://HOST:PORT/hooks/{hook.id} "
+            f"-H 'Content-Type: application/json' "
+            f"-d '{{\"your\": \"payload\"}}'"
+        )
+
+    def _list(self) -> str:
+        hooks = self._hooks.list_hooks(include_disabled=True)
+        if not hooks:
+            return "No registered hooks."
+        lines = []
+        for h in hooks:
+            status = "enabled" if h.enabled else "disabled"
+            lines.append(
+                f"- {h.name} (id: {h.id[:16]}..., mode: {h.mode}, "
+                f"triggers: {h.trigger_count}, {status})"
+            )
+        return "Registered hooks:\n" + "\n".join(lines)
+
+    def _update(self, hook_id: str, name: str, instructions: str, mode: str) -> str:
+        if not hook_id:
+            return "Error: id is required for update"
+
+        changes: dict[str, Any] = {}
+        if name:
+            changes["name"] = name
+        if instructions:
+            changes["instructions"] = instructions
+        if mode and mode in ("alert", "silent"):
+            changes["mode"] = mode
+
+        if not changes:
+            return "Error: nothing to update"
+
+        hook = self._hooks.update_hook(hook_id, **changes)
+        if hook:
+            return f"Updated hook '{hook.name}' ({hook.id[:16]}...)"
+        return "Hook not found"
+
+    def _delete(self, hook_id: str) -> str:
+        if not hook_id:
+            return "Error: id is required for delete"
+        if self._hooks.delete_hook(hook_id):
+            return f"Deleted hook {hook_id[:16]}..."
+        return "Hook not found"
+
+    def _history(self, hook_id: str, limit: int) -> str:
+        if not hook_id:
+            return "Error: id is required for history"
+
+        entries = self._hooks.get_history(hook_id, limit=limit)
+        if not entries:
+            return "No trigger history for this hook."
+
+        lines = []
+        for e in entries:
+            lines.append(
+                f"- [{e.get('timestamp', '?')}] status: {e.get('status', '?')}, "
+                f"duration: {e.get('duration_s', '?')}s"
+            )
+        return f"Last {len(entries)} triggers:\n" + "\n".join(lines)

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -249,7 +249,7 @@ Hooks are event-driven HTTP endpoints — external scripts trigger the agent via
 
 **Before creating, modifying, or advising on hooks, ALWAYS load the `hooks` skill first** by reading its SKILL.md with `file_read`. The skill contains critical guidance: how to write effective instructions, payload design, trigger script patterns, the self-authoring workflow, and all hook archetypes (alert, silent, conditional, action, history-aware, multi-hook pipelines). Do not wing it from the tool description alone — the skill has the patterns.
 
-The `hook` tool handles registration (`create`, `list`, `update`, `delete`, `history`). The hooks HTTP server runs on a dedicated port (default 18791) and starts automatically with the gateway.
+The `hook` tool handles registration (`create`, `list`, `update`, `delete`, `history`).
 
 ---
 

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -243,6 +243,16 @@ This means you can see in conversation history that a cron job ran, without it t
 
 ---
 
+## Hooks Protocol
+
+Hooks are event-driven HTTP endpoints — external scripts trigger the agent via HTTP POST, and the agent processes the payload autonomously.
+
+**Before creating, modifying, or advising on hooks, ALWAYS load the `hooks` skill first** by reading its SKILL.md with `file_read`. The skill contains critical guidance: how to write effective instructions, payload design, trigger script patterns, the self-authoring workflow, and all hook archetypes (alert, silent, conditional, action, history-aware, multi-hook pipelines). Do not wing it from the tool description alone — the skill has the patterns.
+
+The `hook` tool handles registration (`create`, `list`, `update`, `delete`, `history`). The hooks HTTP server runs on a dedicated port (default 18791) and starts automatically with the gateway.
+
+---
+
 ## Response Protocol
 
 How you deliver your response depends on the situation.

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -169,9 +169,9 @@ Create and manage webhook hooks — HTTP endpoints that external scripts can tri
 - `history` — show recent triggers for a hook. Requires `id`. Optional: `limit` (default 10).
 
 **How hooks work:**
-- External scripts send `POST /hooks/{id}` with a payload body to the hooks port (default 18791).
-- The hook's `id` doubles as the auth secret — knowing it grants trigger access.
-- The hook's `instructions` define what to do with the payload — they're the system prompt for an isolated agent session.
+- External scripts send `POST /hooks/{{hook_id}}` with a payload body to the hooks port (default 18791).
+- The hook's ID doubles as the auth secret — knowing it grants trigger access.
+- The hook's instructions define what to do with the payload — they're the system prompt for an isolated agent session.
 - In `alert` mode (default), the handler processes the payload and delivers the result to the user's chat via `deliver_result`.
 - In `silent` mode, the trigger is logged but no message is delivered unless the instructions explicitly call for it.
 - The handler is a full agent — it can run commands, read files, make web requests, and then deliver a result (or stay silent).

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -158,6 +158,26 @@ If the result references a file, include its absolute path, not a workspace-rela
 
 Execution history is stored at `{data_root}/cron/logs/{{job_id}}.jsonl`. Each entry contains timestamp, status, duration, input, and output. Logs persist even after one-shot jobs auto-delete. Use `file_read` to inspect them.
 
+## Hooks
+
+### hook
+Create and manage webhook hooks — HTTP endpoints that external scripts can trigger. Actions:
+- `create` — register a new hook. Requires `name` and `instructions`. Optional: `mode` ("alert" or "silent", default "alert"). Returns `id` (which is also the URL path and auth secret) and trigger URL.
+- `list` — show all registered hooks with ID, name, mode, trigger count, and status.
+- `update` — modify a hook. Requires `id`. Supports: `name`, `instructions`, `mode`.
+- `delete` — remove a hook by `id`.
+- `history` — show recent triggers for a hook. Requires `id`. Optional: `limit` (default 10).
+
+**How hooks work:**
+- External scripts send `POST /hooks/{id}` with a payload body to the hooks port (default 18791).
+- The hook's `id` doubles as the auth secret — knowing it grants trigger access.
+- The hook's `instructions` define what to do with the payload — they're the system prompt for an isolated agent session.
+- In `alert` mode (default), the handler processes the payload and delivers the result to the user's chat via `deliver_result`.
+- In `silent` mode, the trigger is logged but no message is delivered unless the instructions explicitly call for it.
+- The handler is a full agent — it can run commands, read files, make web requests, and then deliver a result (or stay silent).
+
+**Hook logs** are stored at `{data_root}/hooks/logs/{{hook_id}}.jsonl`.
+
 ## Heartbeat
 
 ### heartbeat

--- a/ragnarbot/builtin/HOOK_ISOLATED.md
+++ b/ragnarbot/builtin/HOOK_ISOLATED.md
@@ -1,0 +1,27 @@
+# Hook Trigger (Isolated Mode)
+
+You are processing a webhook trigger. This is NOT an interactive conversation.
+
+**Hook:** {hook_name}
+**Mode:** {hook_mode}
+**Current time:** {current_time}
+**Workspace:** {workspace_path}
+
+## Instructions
+
+{instructions}
+
+## Incoming Payload
+
+```
+{payload}
+```
+
+## Rules
+
+1. Process the payload according to the instructions above.
+2. Use `deliver_result` to send output to the user. If mode is "alert", you SHOULD deliver unless the instructions say otherwise. If mode is "silent", only deliver if the instructions explicitly say to.
+3. No conversation. Don't ask questions or wait for input.
+4. Be concise. The result should be actionable, not a process log.
+5. You have fresh context with no session history. All information you need should be in the instructions, the payload, or obtainable via tools.
+6. If you mention a file in the result, include its absolute path under the workspace above — not a relative path.

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -270,6 +270,8 @@ def gateway_main(
     from ragnarbot.cron.service import CronService
     from ragnarbot.cron.types import CronJob
     from ragnarbot.heartbeat.service import HeartbeatService
+    from ragnarbot.hooks.service import HookService
+    from ragnarbot.hooks.types import HookDefinition
     from ragnarbot.media.manager import MediaManager
 
     if verbose:
@@ -320,6 +322,10 @@ def gateway_main(
         cron_store_path = get_data_dir() / "cron" / "jobs.json"
         cron = CronService(cron_store_path)
 
+        hooks_store_path = get_data_dir() / "hooks" / "hooks.json"
+        hooks_logs_dir = get_data_dir() / "hooks" / "logs"
+        hook_service = HookService(hooks_store_path, hooks_logs_dir)
+
         agent = AgentLoop(
             bus=bus,
             provider=provider,
@@ -329,6 +335,7 @@ def gateway_main(
             search_engine=search_engine,
             exec_config=config.tools.exec,
             cron_service=cron,
+            hook_service=hook_service,
             stream_steps=config.agents.defaults.stream_steps,
             media_manager=media_manager,
             debounce_seconds=config.agents.defaults.debounce_seconds,
@@ -431,6 +438,71 @@ def gateway_main(
 
         cron.on_job = on_cron_job
 
+        async def on_hook_trigger(hook: HookDefinition, payload: str) -> str | None:
+            """Execute a hook trigger through the agent."""
+            import time as _time
+
+            start_time = _time.time()
+            response = None
+            status = "ok"
+            error = None
+
+            try:
+                response = await agent.process_hook_isolated(
+                    hook_name=hook.name,
+                    instructions=hook.instructions,
+                    payload=payload,
+                    mode=hook.mode,
+                    channel=hook.channel or "cli",
+                    chat_id=hook.to or "direct",
+                )
+                if response and hook.to:
+                    from ragnarbot.bus.events import OutboundMessage
+                    await bus.publish_outbound(OutboundMessage(
+                        channel=hook.channel or "cli",
+                        chat_id=hook.to,
+                        content=response,
+                    ))
+            except Exception as e:
+                status = "error"
+                error = str(e)
+                raise
+            finally:
+                duration = _time.time() - start_time
+                hook_service.log_trigger(hook, payload, status, duration, response, error)
+
+                if hook.to:
+                    try:
+                        channel = hook.channel or "cli"
+                        session_key = f"{channel}:{hook.to}"
+                        session = agent.sessions.get_or_create(session_key)
+                        ts = _time.strftime("%Y-%m-%d %H:%M:%S")
+                        marker = (
+                            f"[Hook triggered: {hook.name} | id: {hook.id[:16]}... "
+                            f"| {ts} | status: {status}]"
+                        )
+                        session.add_message("assistant", marker)
+                        agent.sessions.save(session)
+                    except Exception as marker_err:
+                        from loguru import logger as _log
+                        _log.warning(f"Failed to save hook marker: {marker_err}")
+
+            return response
+
+        hook_service.on_trigger = on_hook_trigger
+
+        # Create hook HTTP server if enabled
+        hook_server = None
+        if config.hooks.enabled:
+            from ragnarbot.hooks.server import HookServer
+            hook_server = HookServer(
+                service=hook_service,
+                host=config.gateway.host,
+                port=config.hooks.port,
+                max_payload_bytes=config.hooks.max_payload_bytes,
+                rate_limit_per_hook=config.hooks.rate_limit_per_hook,
+            )
+
         import time as _time
 
         from ragnarbot.bus.events import InboundMessage as _InboundMessage
@@ -488,6 +560,18 @@ def gateway_main(
 
         hb_status = f"every {config.heartbeat.interval_m}m" if config.heartbeat.enabled else "disabled"
         console.print(f"[green]✓[/green] Heartbeat: {hb_status}")
+
+        hooks_count = len(hook_service.list_hooks(include_disabled=True))
+        if config.hooks.enabled:
+            console.print(
+                f"[green]✓[/green] Hooks: port {config.hooks.port}, "
+                f"{hooks_count} registered"
+            )
+        elif hooks_count > 0:
+            console.print(
+                f"[yellow]![/yellow] Hooks: disabled ({hooks_count} registered, "
+                f"enable with hooks.enabled=true)"
+            )
 
         async def run():
             _reconcile_pending_update_after_startup()
@@ -593,6 +677,8 @@ def gateway_main(
             try:
                 await cron.start()
                 await heartbeat.start()
+                if hook_server:
+                    await hook_server.start()
 
                 agent_task = asyncio.create_task(agent.run())
                 channel_task = asyncio.create_task(channels.start_all())
@@ -611,12 +697,16 @@ def gateway_main(
                         pass
 
                 # Cleanup
+                if hook_server:
+                    await hook_server.stop()
                 await agent.browser_manager.close_all()
                 heartbeat.stop()
                 cron.stop()
                 await channels.stop_all()
             except KeyboardInterrupt:
                 console.print("\nShutting down...")
+                if hook_server:
+                    await hook_server.stop()
                 await agent.browser_manager.close_all()
                 heartbeat.stop()
                 cron.stop()

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -220,6 +220,28 @@ class HeartbeatConfig(BaseModel):
     )
 
 
+class HooksConfig(BaseModel):
+    """Webhook hooks configuration."""
+    enabled: bool = Field(
+        default=False,
+        json_schema_extra={"reload": "warm", "label": "Enable webhook hooks HTTP server"},
+    )
+    port: int = Field(
+        default=18791,
+        json_schema_extra={"reload": "warm", "label": "Hooks HTTP server port"},
+    )
+    rate_limit_per_hook: int = Field(
+        default=60,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Max triggers per hook per minute"},
+    )
+    max_payload_bytes: int = Field(
+        default=65536,
+        ge=1024,
+        json_schema_extra={"reload": "hot", "label": "Max hook payload size (bytes)"},
+    )
+
+
 class Config(BaseSettings):
     """Root configuration for ragnarbot."""
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
@@ -227,6 +249,7 @@ class Config(BaseSettings):
     daemon: DaemonConfig = Field(default_factory=DaemonConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    hooks: HooksConfig = Field(default_factory=HooksConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
 

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -223,7 +223,7 @@ class HeartbeatConfig(BaseModel):
 class HooksConfig(BaseModel):
     """Webhook hooks configuration."""
     enabled: bool = Field(
-        default=False,
+        default=True,
         json_schema_extra={"reload": "warm", "label": "Enable webhook hooks HTTP server"},
     )
     port: int = Field(

--- a/ragnarbot/hooks/server.py
+++ b/ragnarbot/hooks/server.py
@@ -1,0 +1,101 @@
+"""HTTP server for receiving hook triggers."""
+
+import asyncio
+import time
+
+from aiohttp import web
+from loguru import logger
+
+from ragnarbot.hooks.service import HookService
+
+
+class HookServer:
+    """Lightweight aiohttp server exposing POST /hooks/{hook_id} for triggers."""
+
+    def __init__(
+        self,
+        service: HookService,
+        host: str = "0.0.0.0",
+        port: int = 18791,
+        max_payload_bytes: int = 65536,
+        rate_limit_per_hook: int = 60,
+    ):
+        self.service = service
+        self.host = host
+        self.port = port
+        self.max_payload_bytes = max_payload_bytes
+        self.rate_limit_per_hook = rate_limit_per_hook
+
+        self._rate_windows: dict[str, list[float]] = {}
+        self._runner: web.AppRunner | None = None
+
+        self.app = web.Application()
+        self.app.router.add_get("/hooks/health", self._handle_health)
+        self.app.router.add_post("/hooks/{hook_id}", self._handle_trigger)
+
+    # ========== Lifecycle ==========
+
+    async def start(self) -> None:
+        self._runner = web.AppRunner(self.app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        logger.info(f"Hook server listening on {self.host}:{self.port}")
+
+    async def stop(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            logger.info("Hook server stopped")
+
+    # ========== Handlers ==========
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok"})
+
+    async def _handle_trigger(self, request: web.Request) -> web.Response:
+        hook_id = request.match_info["hook_id"]
+
+        # Look up hook by ID (which is also the secret)
+        hook = self.service.get_hook(hook_id)
+        if hook is None or not hook.enabled:
+            return web.json_response(
+                {"error": "not found"}, status=404,
+            )
+
+        # Rate limiting (sliding window, 1 minute)
+        now = time.time()
+        window = self._rate_windows.setdefault(hook_id, [])
+        cutoff = now - 60.0
+        window[:] = [t for t in window if t > cutoff]
+        if len(window) >= self.rate_limit_per_hook:
+            return web.json_response(
+                {"error": "rate limit exceeded"}, status=429,
+            )
+        window.append(now)
+
+        # Read payload with size limit
+        try:
+            payload = await request.text()
+            if len(payload.encode("utf-8")) > self.max_payload_bytes:
+                return web.json_response(
+                    {"error": "payload too large"}, status=413,
+                )
+        except Exception:
+            payload = ""
+
+        # Dispatch trigger asynchronously — respond 202 immediately
+        self.service.increment_trigger_count(hook_id)
+        asyncio.create_task(self._dispatch_trigger(hook, payload))
+
+        return web.json_response(
+            {"status": "accepted", "hook": hook.name}, status=202,
+        )
+
+    async def _dispatch_trigger(self, hook, payload: str) -> None:
+        """Run the trigger callback in the background."""
+        try:
+            if self.service.on_trigger:
+                await self.service.on_trigger(hook, payload)
+        except Exception as e:
+            logger.error(f"Hook trigger failed for '{hook.name}': {e}")

--- a/ragnarbot/hooks/server.py
+++ b/ragnarbot/hooks/server.py
@@ -39,7 +39,16 @@ class HookServer:
         self._runner = web.AppRunner(self.app)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self.host, self.port)
-        await site.start()
+        try:
+            await site.start()
+        except OSError as e:
+            await self._runner.cleanup()
+            self._runner = None
+            logger.error(
+                f"Hook server failed to bind {self.host}:{self.port}: {e}. "
+                f"Change hooks.port in config if another profile uses this port."
+            )
+            return
         logger.info(f"Hook server listening on {self.host}:{self.port}")
 
     async def stop(self) -> None:

--- a/ragnarbot/hooks/service.py
+++ b/ragnarbot/hooks/service.py
@@ -1,0 +1,213 @@
+"""Hook service — CRUD, storage, and trigger logging."""
+
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Callable, Coroutine
+
+from loguru import logger
+
+from ragnarbot.hooks.types import HookDefinition, HookStore
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _generate_hook_id() -> str:
+    """Generate a cryptographic hook ID that doubles as the auth secret."""
+    return f"hk_{secrets.token_urlsafe(32)}"
+
+
+class HookService:
+    """Manages hook registration, persistence, and trigger logging."""
+
+    def __init__(
+        self,
+        store_path: Path,
+        logs_dir: Path,
+        on_trigger: (
+            Callable[[HookDefinition, str], Coroutine[Any, Any, str | None]] | None
+        ) = None,
+    ):
+        self.store_path = store_path
+        self.logs_dir = logs_dir
+        self.on_trigger = on_trigger
+        self._store: HookStore | None = None
+
+    # ========== Store I/O ==========
+
+    def _load_store(self) -> HookStore:
+        if self._store:
+            return self._store
+
+        if self.store_path.exists():
+            try:
+                data = json.loads(self.store_path.read_text())
+                hooks = []
+                for h in data.get("hooks", []):
+                    hooks.append(HookDefinition(
+                        id=h["id"],
+                        name=h["name"],
+                        instructions=h.get("instructions", ""),
+                        mode=h.get("mode", "alert"),
+                        enabled=h.get("enabled", True),
+                        channel=h.get("channel"),
+                        to=h.get("to"),
+                        created_at_ms=h.get("createdAtMs", 0),
+                        updated_at_ms=h.get("updatedAtMs", 0),
+                        trigger_count=h.get("triggerCount", 0),
+                    ))
+                self._store = HookStore(hooks=hooks)
+            except Exception as e:
+                logger.warning(f"Failed to load hook store: {e}")
+                self._store = HookStore()
+        else:
+            self._store = HookStore()
+
+        return self._store
+
+    def _save_store(self) -> None:
+        if not self._store:
+            return
+
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "version": self._store.version,
+            "hooks": [
+                {
+                    "id": h.id,
+                    "name": h.name,
+                    "instructions": h.instructions,
+                    "mode": h.mode,
+                    "enabled": h.enabled,
+                    "channel": h.channel,
+                    "to": h.to,
+                    "createdAtMs": h.created_at_ms,
+                    "updatedAtMs": h.updated_at_ms,
+                    "triggerCount": h.trigger_count,
+                }
+                for h in self._store.hooks
+            ],
+        }
+
+        self.store_path.write_text(json.dumps(data, indent=2))
+
+    # ========== CRUD ==========
+
+    def add_hook(
+        self,
+        name: str,
+        instructions: str,
+        mode: str = "alert",
+        channel: str | None = None,
+        to: str | None = None,
+    ) -> HookDefinition:
+        store = self._load_store()
+        now = _now_ms()
+        hook = HookDefinition(
+            id=_generate_hook_id(),
+            name=name,
+            instructions=instructions,
+            mode=mode if mode in ("alert", "silent") else "alert",
+            channel=channel,
+            to=to,
+            created_at_ms=now,
+            updated_at_ms=now,
+        )
+        store.hooks.append(hook)
+        self._save_store()
+        logger.info(f"Hook created: '{hook.name}' ({hook.id[:16]}...)")
+        return hook
+
+    def get_hook(self, hook_id: str) -> HookDefinition | None:
+        store = self._load_store()
+        for h in store.hooks:
+            if h.id == hook_id:
+                return h
+        return None
+
+    def list_hooks(self, include_disabled: bool = False) -> list[HookDefinition]:
+        store = self._load_store()
+        if include_disabled:
+            return list(store.hooks)
+        return [h for h in store.hooks if h.enabled]
+
+    def update_hook(self, hook_id: str, **changes: Any) -> HookDefinition | None:
+        store = self._load_store()
+        for h in store.hooks:
+            if h.id == hook_id:
+                if "name" in changes:
+                    h.name = changes["name"]
+                if "instructions" in changes:
+                    h.instructions = changes["instructions"]
+                if "mode" in changes and changes["mode"] in ("alert", "silent"):
+                    h.mode = changes["mode"]
+                if "enabled" in changes:
+                    h.enabled = changes["enabled"]
+                h.updated_at_ms = _now_ms()
+                self._save_store()
+                return h
+        return None
+
+    def delete_hook(self, hook_id: str) -> bool:
+        store = self._load_store()
+        before = len(store.hooks)
+        store.hooks = [h for h in store.hooks if h.id != hook_id]
+        if len(store.hooks) < before:
+            self._save_store()
+            return True
+        return False
+
+    def increment_trigger_count(self, hook_id: str) -> None:
+        store = self._load_store()
+        for h in store.hooks:
+            if h.id == hook_id:
+                h.trigger_count += 1
+                self._save_store()
+                return
+
+    # ========== Logging ==========
+
+    def log_trigger(
+        self,
+        hook: HookDefinition,
+        payload: str,
+        status: str,
+        duration_s: float,
+        output: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        log_file = self.logs_dir / f"{hook.id}.jsonl"
+
+        entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "hook_id": hook.id[:16],
+            "hook_name": hook.name,
+            "mode": hook.mode,
+            "payload_preview": payload[:200] if payload else "",
+            "output": output,
+            "status": status,
+            "duration_s": round(duration_s, 2),
+            "error": error,
+        }
+
+        with log_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def get_history(self, hook_id: str, limit: int = 10) -> list[dict]:
+        log_file = self.logs_dir / f"{hook_id}.jsonl"
+        if not log_file.exists():
+            return []
+
+        lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+        entries = []
+        for line in lines[-limit:]:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return entries

--- a/ragnarbot/hooks/types.py
+++ b/ragnarbot/hooks/types.py
@@ -1,0 +1,25 @@
+"""Hook types."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class HookDefinition:
+    """A registered webhook hook."""
+    id: str                    # cryptographic token — doubles as auth secret
+    name: str                  # human-readable name
+    instructions: str          # prompt for the isolated handler session
+    mode: str = "alert"        # "alert" | "silent"
+    enabled: bool = True
+    channel: str | None = None  # delivery channel (e.g. "telegram")
+    to: str | None = None       # delivery chat_id
+    created_at_ms: int = 0
+    updated_at_ms: int = 0
+    trigger_count: int = 0
+
+
+@dataclass
+class HookStore:
+    """Persistent store for registered hooks."""
+    version: int = 1
+    hooks: list[HookDefinition] = field(default_factory=list)

--- a/ragnarbot/instance.py
+++ b/ragnarbot/instance.py
@@ -34,6 +34,8 @@ class InstanceInfo:
     browser_screenshots_path: Path
     cron_dir: Path
     cron_logs_path: Path
+    hooks_dir: Path
+    hooks_logs_path: Path
     log_dir: Path
     fallback_state_path: Path
     pending_grants_path: Path
@@ -140,6 +142,8 @@ def get_instance(profile: str | None = None) -> InstanceInfo:
         browser_screenshots_path=data_root / "browser-screenshots",
         cron_dir=data_root / "cron",
         cron_logs_path=data_root / "cron" / "logs",
+        hooks_dir=data_root / "hooks",
+        hooks_logs_path=data_root / "hooks" / "logs",
         log_dir=data_root / "logs",
         fallback_state_path=data_root / "fallback_state.json",
         pending_grants_path=data_root / "pending_grants.json",

--- a/ragnarbot/skills/hooks/SKILL.md
+++ b/ragnarbot/skills/hooks/SKILL.md
@@ -575,19 +575,17 @@ When the user describes a need, choose the right primitive:
 
 ## Enabling and Configuration
 
-Hooks require explicit enablement. The HTTP server does not start unless configured.
-
-To enable hooks: `config(action="set", path="hooks.enabled", value="true")` — then restart to apply (warm reload).
+Hooks are enabled by default. The HTTP server starts automatically with the gateway.
 
 Configuration options:
-- `hooks.enabled` (bool, default: false) — start the hooks HTTP server
+- `hooks.enabled` (bool, default: true) — start the hooks HTTP server
 - `hooks.port` (int, default: 18791) — HTTP server port
 - `hooks.rateLimitPerHook` (int, default: 60) — max triggers per hook per minute
 - `hooks.maxPayloadBytes` (int, default: 65536) — max POST body size in bytes
 
 The server listens on all interfaces by default. The health endpoint is at `GET /hooks/health` — returns `{"status": "ok"}` when the server is running.
 
-When a user asks to create a hook and hooks are not enabled, enable them first, then restart, then proceed with hook creation. Inform the user that hooks have been enabled.
+If hooks have been explicitly disabled by the user, re-enable them with `config(action="set", path="hooks.enabled", value="true")` and restart before creating hooks.
 
 ## Troubleshooting
 

--- a/ragnarbot/skills/hooks/SKILL.md
+++ b/ragnarbot/skills/hooks/SKILL.md
@@ -1,143 +1,632 @@
 ---
 name: hooks
-description: Guide for creating and managing webhook hooks — event-driven HTTP endpoints that let external scripts trigger the agent. Use when the user wants to set up hooks, write trigger scripts, or design hook-based automation.
+description: Guide for creating and managing webhook hooks — event-driven HTTP endpoints that let external scripts trigger the agent autonomously. Use when the user wants to set up hooks, write trigger scripts, design hook-based automation, connect external systems to the agent, build alert pipelines, or create any reactive "when X happens, do Y" workflow. Also use when discussing the relationship between hooks, cron jobs, and heartbeat.
 ---
 
 # Hooks
 
-Hooks are event-driven HTTP endpoints. External scripts decide WHEN to trigger; the agent decides WHAT to do. This is the opposite of cron (polling) — hooks are reactive.
+Hooks are event-driven HTTP endpoints that turn external events into autonomous agent actions. The core separation of concerns: **the script decides WHEN to trigger, the agent decides WHAT to do.**
+
+Hooks are NOT just alerters. Each trigger spawns a full autonomous agent session with access to every tool — exec, browser, web_search, web_fetch, file operations, cron, other hooks. The handler can research, compare, compute, run commands, write files, and take corrective action before deciding whether to notify the user.
 
 ## How Hooks Work
 
-1. You create a hook with `hook(action="create", name="...", instructions="...")`.
-2. The tool returns a **hook ID** (which is also the URL path and auth secret).
-3. An external script sends `POST /hooks/{hook_id}` with a payload.
-4. The gateway spawns an isolated agent session with the hook's instructions + the payload.
-5. The session processes the payload and optionally delivers a result to the user's chat.
+```
+External script ──POST──> Hook Server ──spawn──> Isolated Agent Session
+                                                    │
+                                                    ├── reads instructions
+                                                    ├── parses payload
+                                                    ├── uses tools (exec, web, files, etc.)
+                                                    ├── optionally calls deliver_result
+                                                    │        │
+                                                    │        └──> message appears in user's chat
+                                                    └── session ends, trigger logged
+```
 
-The hook ID is a long cryptographic token — knowing it grants trigger access. Treat it like a secret.
+Step by step:
+
+1. Create a hook: `hook(action="create", name="...", instructions="...")`
+2. The tool returns a **hook ID** (`hk_...`) — this is the URL path AND the auth secret
+3. External script sends `POST http://HOST:PORT/hooks/{hook_id}` with a payload body
+4. Hook server validates the ID, checks rate limits, reads the payload
+5. An isolated agent session starts with HOOK_ISOLATED.md as system prompt containing: hook name, mode, instructions, payload, workspace path
+6. The session has full tool access and processes the payload per the instructions
+7. If the handler calls `deliver_result(content="...")`, the message appears in the user's chat
+8. A session marker is injected into the user's conversation history: `[Hook triggered: {name} | id: {id} | {ts} | status: ok]`
+9. The trigger is logged to `~/.ragnarbot/hooks/logs/{hook_id}.jsonl`
+
+The isolated session has NO conversation history, NO knowledge of previous messages. It is a fresh agent that sees only: the instructions, the payload, the workspace files, and its tools.
+
+## Hook Tool API
+
+```
+hook(action="create", name="...", instructions="...", mode="alert"|"silent")
+hook(action="list")
+hook(action="update", id="...", name="...", instructions="...", mode="...")
+hook(action="delete", id="...")
+hook(action="history", id="...", limit=10)
+```
+
+- `create` — name and instructions required. Mode defaults to "alert".
+- `list` — shows all hooks with truncated IDs, mode, trigger count, status.
+- `update` — id required. Provide any combination of name, instructions, mode.
+- `delete` — id required. Permanent.
+- `history` — id required. Returns the last N trigger log entries.
 
 ## Writing Instructions
 
-Instructions are the system prompt for the isolated handler session. They must be **self-contained** — the handler has no conversation history and no knowledge of the user beyond workspace files.
+Instructions are the single most important part of a hook. They become the system prompt for the isolated handler. The handler sees ONLY the instructions and the payload — no conversation context, no prior messages, no user preferences beyond what the workspace contains.
 
-Good instructions include:
+### Principles
 
-- **What data arrives**: "You'll receive a JSON payload with `event`, `repo`, and `message` fields."
-- **What to do**: "Summarize the event and deliver it to the user."
-- **When to deliver**: "Only deliver if the event type is 'failure' or 'critical'."
-- **Format**: "Format as a short alert with emoji indicators."
+1. **Self-contained** — include everything the handler needs to know. It cannot ask follow-up questions.
+2. **Describe the expected payload** — the handler needs to know what fields to look for.
+3. **Specify delivery conditions** — when to call `deliver_result` and when to stay silent.
+4. **Define the output format** — the handler will follow whatever format the instructions specify.
+5. **Include error handling** — what to do if the payload is malformed or unexpected.
 
-### Conditional delivery
+### Bad vs Good Instructions
 
-The most powerful pattern — the handler decides whether to alert:
-
-```
-You'll receive a JSON payload from a CI/CD pipeline.
-
-If the build status is "failed" or "error":
-  - Deliver a concise alert with the repo name, branch, and error summary.
-
-If the build status is "success":
-  - Do NOT deliver. The trigger will be logged silently.
-
-If the payload contains a "rollback" field:
-  - Always deliver, regardless of status. Include the rollback reason.
-```
-
-### History-aware hooks
-
-The handler can read previous trigger logs to detect patterns:
+Bad — vague, assumes context:
 
 ```
-You'll receive server metrics as JSON (cpu, memory, disk, latency).
-
-Use file_read to check the last 5 entries in the hook's log file at
-{workspace}/hooks/logs/{hook_id}.jsonl.
-
-If CPU > 90% for 3+ consecutive triggers, deliver an alert.
-If memory usage increased by more than 20% since the previous trigger, deliver a warning.
-Otherwise, do not deliver.
+Handle the CI notification.
 ```
 
-## Generating Trigger Scripts
+The handler has no idea what "CI notification" looks like, what fields matter, or what to deliver.
 
-When the user asks to set up a hook end-to-end, create both the hook AND the trigger script.
+Bad — too rigid, wastes the agent's intelligence:
 
-### curl (simplest)
+```
+Extract the "status" field and send it to the user.
+```
+
+This is a string extraction, not an agent task. A curl + jq pipeline would be better.
+
+Good — structured, specific, leverages agent intelligence:
+
+```
+You receive a JSON payload from GitHub Actions with these fields:
+- action: "completed"
+- workflow_run.conclusion: "success" | "failure" | "cancelled"
+- workflow_run.name: workflow name
+- workflow_run.html_url: link to the run
+- repository.full_name: "owner/repo"
+- workflow_run.head_branch: branch name
+
+Decision logic:
+- If conclusion is "failure": deliver an alert with the repo, workflow name,
+  branch, and a direct link. Use web_fetch on the html_url to extract the
+  specific failing step name if possible.
+- If conclusion is "cancelled": deliver only if the branch is "main" or "master".
+- If conclusion is "success": do NOT deliver.
+
+Format the alert as:
+  [REPO] Workflow "NAME" failed on BRANCH
+  Failing step: STEP (if found)
+  Link: URL
+```
+
+Good — multi-step processing:
+
+```
+You receive a JSON payload with a "url" field pointing to a web page.
+
+1. Use web_fetch to retrieve the page content.
+2. Extract the main article text.
+3. Summarize it in 3-5 bullet points.
+4. Save the full text to {workspace}/hook-data/articles/YYYY-MM-DD-title.md
+5. Deliver the summary to the user with the file path.
+```
+
+Good — history-aware with trend detection:
+
+```
+You receive server metrics as JSON: {cpu, memory_pct, disk_pct, load_avg, timestamp}.
+
+Read the hook's trigger log at ~/.ragnarbot/hooks/logs/{hook_id}.jsonl using
+file_read. Parse the last 10 entries.
+
+Alerting rules:
+- If cpu > 90 for 3+ consecutive triggers: CRITICAL alert
+- If memory_pct increased by 20+ points compared to 1 hour ago: WARNING
+- If disk_pct > 85: WARNING with projected time to full (extrapolate from history)
+- Otherwise: do NOT deliver
+
+When alerting, include the current values, the trend direction (rising/falling/stable),
+and a suggested action.
+```
+
+### Describing Payload Format
+
+Always tell the handler what to expect. Two approaches:
+
+**Enumerated fields** (when the payload structure is known):
+
+```
+The payload is JSON with fields:
+- event_type: string ("push", "pr", "issue")
+- repo: string (e.g. "owner/repo")
+- author: string
+- message: string
+- timestamp: ISO 8601 string
+```
+
+**Open-ended** (when payloads vary):
+
+```
+The payload is a JSON object. The exact structure varies.
+Look for these key fields if present: status, error, message, severity.
+If the payload is not valid JSON, treat it as plain text and summarize it.
+```
+
+### Delivery Guidance by Mode
+
+**Mode "alert"** (default): the handler SHOULD call `deliver_result` unless the instructions explicitly say otherwise for certain conditions. The system prompt tells it: "If mode is alert, you SHOULD deliver unless the instructions say otherwise."
+
+**Mode "silent"**: the handler should NOT deliver unless the instructions explicitly say to. The system prompt tells it: "If mode is silent, only deliver if the instructions explicitly say to."
+
+Use "alert" mode with conditional delivery logic in instructions for most cases. Use "silent" mode for data collection, logging, and background processing where delivery is the exception.
+
+## Payload Design
+
+When generating trigger scripts, structure payloads for maximum handler effectiveness.
+
+### Best Practices
+
+1. **Use JSON** — the handler parses it naturally
+2. **Include metadata** — timestamp, source, severity help the handler make decisions
+3. **Keep it focused** — send what matters, not raw dumps
+4. **Use consistent field names** — across hooks that process similar events
+
+### Recommended Payload Structure
+
+```json
+{
+  "event": "descriptive_event_name",
+  "source": "system-or-service-name",
+  "timestamp": "2025-01-15T14:30:00Z",
+  "severity": "info|warning|error|critical",
+  "data": {
+    // event-specific fields
+  }
+}
+```
+
+### What NOT to Send
+
+- Full log files (use a file path or URL instead)
+- Binary data (save to disk, send the path)
+- Secrets or credentials
+- Payloads over 64KB (default limit) — summarize or reference external data
+
+## Trigger Scripts
+
+When the user asks to set up a hook end-to-end, create BOTH the hook AND the trigger script. Store the hook ID as an environment variable, never hardcoded.
+
+### Shell (curl)
 
 ```bash
-#!/bin/bash
-HOOK_URL="http://localhost:18791/hooks/hk_abc123..."
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Example: send JSON payload
-curl -s -X POST "$HOOK_URL" \
+# Load hook ID from environment or .env file
+HOOK_ID="${RAGNARBOT_HOOK_CI:-}"
+if [[ -z "$HOOK_ID" ]]; then
+  echo "Error: RAGNARBOT_HOOK_CI not set" >&2
+  exit 1
+fi
+
+HOOK_URL="http://localhost:18791/hooks/${HOOK_ID}"
+
+payload=$(cat <<EOF
+{
+  "event": "build_complete",
+  "source": "ci",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "data": {
+    "repo": "${REPO_NAME:-unknown}",
+    "branch": "${BRANCH:-unknown}",
+    "status": "${BUILD_STATUS:-unknown}",
+    "commit": "${COMMIT_SHA:-unknown}"
+  }
+}
+EOF
+)
+
+response=$(curl -s -w "\n%{http_code}" -X POST "$HOOK_URL" \
   -H "Content-Type: application/json" \
-  -d '{"event": "deploy", "status": "success", "repo": "myapp"}'
+  -d "$payload")
+
+http_code=$(echo "$response" | tail -1)
+body=$(echo "$response" | head -1)
+
+if [[ "$http_code" != "202" ]]; then
+  echo "Hook trigger failed (HTTP $http_code): $body" >&2
+  exit 1
+fi
 ```
 
 ### Python
 
 ```python
-import requests
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
 
-HOOK_URL = "http://localhost:18791/hooks/hk_abc123..."
+HOOK_ID = os.environ.get("RAGNARBOT_HOOK_MONITOR")
+if not HOOK_ID:
+    print("Error: RAGNARBOT_HOOK_MONITOR not set", file=sys.stderr)
+    sys.exit(1)
 
-payload = {"event": "deploy", "status": "success"}
-resp = requests.post(HOOK_URL, json=payload)
-print(resp.status_code, resp.json())
+HOOK_URL = f"http://localhost:18791/hooks/{HOOK_ID}"
+
+payload = {
+    "event": "health_check",
+    "source": "monitor",
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "data": {
+        "cpu": get_cpu_percent(),
+        "memory": get_memory_percent(),
+        "disk": get_disk_percent(),
+    },
+}
+
+req = Request(
+    HOOK_URL,
+    data=json.dumps(payload).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+
+try:
+    with urlopen(req, timeout=10) as resp:
+        print(f"Triggered: {resp.status}")
+except HTTPError as e:
+    print(f"Hook error: {e.code} {e.read().decode()}", file=sys.stderr)
+except URLError as e:
+    print(f"Connection error: {e.reason}", file=sys.stderr)
 ```
 
-### Scheduling triggers externally
+The Python example uses only stdlib (`urllib`) so no dependencies are needed. For more complex scripts, `requests` or `httpx` are fine.
 
-Hook scripts can be scheduled with any external mechanism:
+### GitHub Actions
 
-- **crontab**: `*/5 * * * * /path/to/trigger_script.sh` — every 5 minutes
-- **launchd** (macOS): plist with `StartInterval`
-- **systemd timer** (Linux): `.timer` unit
-- **fswatch/inotifywait**: trigger on file changes
-- **CI/CD webhooks**: GitHub Actions, GitLab CI, etc.
+```yaml
+- name: Notify Ragnarbot
+  if: failure()
+  run: |
+    curl -s -X POST "http://${{ secrets.RAGNARBOT_HOST }}/hooks/${{ secrets.RAGNARBOT_HOOK_CI }}" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "event": "ci_failure",
+        "source": "github_actions",
+        "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
+        "data": {
+          "repo": "${{ github.repository }}",
+          "branch": "${{ github.ref_name }}",
+          "workflow": "${{ github.workflow }}",
+          "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          "actor": "${{ github.actor }}"
+        }
+      }'
+```
 
-## Security
+Note: GitHub Actions requires an external-facing URL. The user needs a tunnel (ngrok, cloudflared) or a publicly accessible host.
 
-- The hook ID IS the secret. Never expose it in logs, commits, or public repos.
-- Store the hook ID in an environment variable or a secrets file, not hardcoded in scripts.
-- The hooks server only listens locally by default. For external access, use a tunnel (ngrok, cloudflared, SSH tunnel).
-- Each hook has independent rate limiting.
+### File Watcher (fswatch)
 
-## Patterns
+```bash
+#!/usr/bin/env bash
+HOOK_ID="${RAGNARBOT_HOOK_FILEWATCHER}"
+WATCH_DIR="/path/to/watched/directory"
 
-### Alert hook
-The default pattern. Every trigger delivers a message to the user.
-- Mode: `alert`
-- Instructions: "Summarize the payload and deliver it."
-- Use for: notifications, CI alerts, monitoring
+fswatch -0 --event Created --event Updated "$WATCH_DIR" | while read -d "" file; do
+  curl -s -X POST "http://localhost:18791/hooks/${HOOK_ID}" \
+    -H "Content-Type: application/json" \
+    -d "{\"event\": \"file_changed\", \"data\": {\"path\": \"$file\", \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}"
+done
+```
 
-### Silent hook
-Triggers are logged but nothing is delivered.
-- Mode: `silent`
-- Instructions: "Process the payload and save results to a file."
-- Use for: data collection, logging, background sync
+### Securing Hook IDs
 
-### Conditional hook
-The handler inspects the payload and decides whether to deliver.
-- Mode: `alert` (handler can choose not to call `deliver_result`)
-- Instructions include conditional logic
-- Use for: smart monitoring, threshold-based alerts, deduplication
+- Store in environment variables: `export RAGNARBOT_HOOK_CI="hk_abc123..."`
+- Use `.env` files (gitignored): `RAGNARBOT_HOOK_CI=hk_abc123...`
+- CI/CD secrets: GitHub Secrets, GitLab CI Variables, etc.
+- Never commit hook IDs to version control
+- Never log the full hook ID (the system truncates it in logs for this reason)
 
-### Action hook
-The handler doesn't just alert — it takes action (runs commands, edits files, makes API calls) and then reports what it did.
-- Mode: `alert`
-- Instructions: "If the payload indicates a failing health check, restart the service via exec, then deliver the result."
-- Use for: auto-remediation, automated workflows
+## The Self-Authoring Pattern
+
+The ideal user experience: the user describes what they want in natural language, and the agent handles everything — creating the hook, writing the trigger script, deploying it, and confirming it works. The user never needs to see a hook ID, a URL, or a payload format.
+
+### Full Cycle
+
+1. **User describes the goal**: "Notify me when my CI pipeline fails"
+2. **Agent creates the hook**: `hook(action="create", name="ci-failure-alert", instructions="...", mode="alert")`
+3. **Agent writes the trigger script**: creates a shell/Python script in the workspace, injects the hook ID via environment variable
+4. **Agent deploys the script**: adds a crontab entry, creates a launchd plist, or sets up fswatch — whatever the platform needs
+5. **Agent confirms**: tells the user what was set up, how it works, and how to test it
+6. **User starts receiving results**: hook fires, handler processes, user sees the alert
+
+### Important: Manage the Complexity
+
+The user should NOT need to understand hook IDs, URLs, payload formats, or HTTP. The agent abstracts all of this. When explaining what was set up, focus on what happens ("when your CI fails, you'll get a notification with the error details") not how ("the script sends a POST request to the hooks endpoint with a JSON payload").
+
+When the user asks to modify or delete a hook, use `hook(action="list")` to find it by name, then operate on it. Do not ask the user for the hook ID.
+
+## Hook Patterns
+
+### Pattern 1: Alert Hook
+
+Every trigger delivers a message. The simplest pattern.
+
+Mode: `alert`
+
+Example — deploy notification:
+
+```
+hook(action="create", name="deploy-notify", mode="alert", instructions="""
+You receive a JSON payload about a deployment:
+- app: application name
+- environment: "staging" | "production"
+- version: deployed version
+- deployer: who triggered it
+- timestamp: when it happened
+
+Format and deliver:
+  Deploy: APP vVERSION -> ENVIRONMENT
+  By: DEPLOYER at TIME
+""")
+```
+
+### Pattern 2: Silent Hook
+
+Triggers are logged and data is collected, but nothing is delivered. The handler processes data for later analysis.
+
+Mode: `silent`
+
+Example — metrics collector:
+
+```
+hook(action="create", name="metrics-collector", mode="silent", instructions="""
+You receive a JSON payload with server metrics: cpu, memory, disk, latency.
+
+Append a formatted line to {workspace}/data/metrics.csv:
+  timestamp,cpu,memory,disk,latency
+
+Create the file with headers if it doesn't exist.
+Do NOT deliver a result — this is a data collection hook.
+""")
+```
+
+### Pattern 3: Conditional Hook
+
+The handler inspects the payload and decides whether to deliver. This is the most common real-world pattern.
+
+Mode: `alert` (the handler may choose not to call deliver_result)
+
+Example — smart CI notifications:
+
+```
+hook(action="create", name="ci-monitor", mode="alert", instructions="""
+You receive a JSON payload from CI/CD:
+- repo: repository name
+- branch: branch name
+- status: "success" | "failure" | "error" | "cancelled"
+- workflow: workflow name
+- url: link to the run
+- error_message: present only on failure
+
+Decision logic:
+- status "failure" or "error" on main/master branch: ALWAYS deliver
+- status "failure" on other branches: deliver ONLY if error_message contains
+  "test" or "lint" (code quality issues)
+- status "cancelled": never deliver
+- status "success": deliver ONLY if the previous trigger (check the hook log
+  at ~/.ragnarbot/hooks/logs/{hook_id}.jsonl) was a failure — this signals recovery
+
+When delivering, include: repo, branch, status, and a direct link.
+On recovery, note: "Previously failing, now passing."
+""")
+```
+
+### Pattern 4: Action Hook
+
+The handler takes action (runs commands, writes files, calls APIs) THEN reports what it did.
+
+Mode: `alert`
+
+Example — auto-restart on health check failure:
+
+```
+hook(action="create", name="service-guardian", mode="alert", instructions="""
+You receive a JSON payload from a health check script:
+- service: service name (e.g. "nginx", "postgres", "myapp")
+- status: "healthy" | "unhealthy" | "timeout"
+- endpoint: the URL that was checked
+- response_time_ms: response time (if available)
+- error: error message (if unhealthy)
+
+If status is "healthy": do NOT deliver.
+
+If status is "unhealthy" or "timeout":
+1. Use exec to check if the service process is running: `pgrep -f {service}` or `systemctl is-active {service}`
+2. If the process is not running, attempt restart: `systemctl restart {service}`
+3. Wait 5 seconds, then check the endpoint again using web_fetch
+4. Deliver a report:
+   - What was wrong
+   - What action was taken
+   - Whether the service recovered
+   - Current status
+
+If you cannot restart (permission denied, not found), deliver the error details
+and suggest manual intervention.
+""")
+```
+
+### Pattern 5: History-Aware Hook
+
+The handler reads previous trigger logs to detect trends, anomalies, or state changes over time.
+
+Mode: `alert`
+
+Example — anomaly detection:
+
+```
+hook(action="create", name="traffic-anomaly", mode="alert", instructions="""
+You receive a JSON payload with web traffic metrics:
+- requests_per_minute: integer
+- error_rate_pct: float
+- avg_response_ms: integer
+- timestamp: ISO 8601
+
+Read the trigger log at ~/.ragnarbot/hooks/logs/{hook_id}.jsonl using file_read.
+Parse the last 20 entries to establish baseline.
+
+Anomaly rules:
+- If requests_per_minute is more than 3x the average of the last 20 entries: SPIKE alert
+- If requests_per_minute drops below 10% of the average: DROP alert
+- If error_rate_pct exceeds 5% and the previous 3 entries were below 2%: ERROR SURGE alert
+- If avg_response_ms exceeds 2x the recent average for 5+ consecutive triggers: SLOWDOWN alert
+
+When alerting, include:
+- The anomaly type
+- Current value vs baseline average
+- How long the anomaly has persisted (count of consecutive anomalous triggers)
+- A trend line description (accelerating, stabilizing, new occurrence)
+
+If no anomaly detected, do NOT deliver.
+""")
+```
+
+### Pattern 6: Multi-Hook Pipeline
+
+Multiple hooks with different responsibilities triggered by the same event or in sequence. One event, several specialized responses.
+
+Example — deployment pipeline with three hooks:
+
+**Hook 1: Deploy validator** — checks if the deploy is safe
+
+```
+hook(action="create", name="deploy-validator", mode="alert", instructions="""
+You receive a deploy intent payload with: app, version, environment, changes_url.
+
+1. Use web_fetch on changes_url to get the changelog/diff
+2. Check for risky patterns: database migrations, config changes, dependency updates
+3. If environment is "production" and changes include migrations:
+   deliver a WARNING with the migration details and ask for confirmation
+4. If changes look routine: deliver a short "Deploy looks safe" confirmation
+""")
+```
+
+**Hook 2: Deploy monitor** — watches for post-deploy issues
+
+```
+hook(action="create", name="deploy-monitor", mode="alert", instructions="""
+You receive a post-deploy health payload with: app, version, environment, health_status, error_count, latency_ms.
+
+Compare with the previous 5 triggers in the hook log.
+
+If error_count increased by more than 50% since the pre-deploy baseline: deliver a ROLLBACK warning
+If latency_ms increased by more than 100%: deliver a DEGRADATION warning
+If health_status is "healthy" and metrics are stable: do NOT deliver
+""")
+```
+
+**Hook 3: Deploy logger** — records everything silently
+
+```
+hook(action="create", name="deploy-log", mode="silent", instructions="""
+Append the full payload as a structured entry to {workspace}/data/deploy-history.jsonl.
+Include a parsed summary line. Do NOT deliver.
+""")
+```
+
+The trigger scripts can fire all three from the same deployment pipeline at different stages.
 
 ## Relationship to Cron and Heartbeat
 
-- **Cron**: polling — the agent runs tasks on a schedule. Best for "do X every N minutes."
-- **Heartbeat**: periodic context check — the agent reviews tasks on an interval. Best for ongoing awareness.
-- **Hooks**: reactive — external events trigger the agent. Best for "when X happens, do Y."
+| Feature | Trigger | Best for |
+|---------|---------|----------|
+| **Cron** | Scheduled (time-based) | "Do X every N minutes" — polling, periodic tasks |
+| **Heartbeat** | Periodic (interval-based) | Ongoing awareness, context review, nudges |
+| **Hooks** | Reactive (event-based) | "When X happens, do Y" — external events, webhooks |
 
-These complement each other:
-- A cron job can run a script that triggers a hook (scheduled event-driven processing).
-- A hook can create/modify cron jobs (event triggers recurring monitoring).
-- Heartbeat provides context; hooks provide events; cron provides schedules.
+These are complementary, not competing:
+
+**Cron triggers hooks**: a cron job runs a monitoring script every 5 minutes; the script collects data and triggers a hook for intelligent processing. The cron handles timing, the hook handles decision-making.
+
+**Hooks create cron jobs**: a deploy hook receives notification of a new deployment and creates a temporary cron job to monitor health every minute for the next hour. After the hour, the cron job cleans itself up.
+
+**Hooks trigger other hooks**: a data-collection hook receives raw data, processes it, and triggers a separate analysis hook with the processed results. Pipeline pattern.
+
+**Cron + hooks as poll-and-react**: a cron job polls an API every 10 minutes, compares with the previous result, and triggers a hook ONLY if something changed. Efficient event detection without real-time webhooks.
+
+When the user describes a need, choose the right primitive:
+- "Tell me every morning about..." -> cron
+- "When my CI fails..." -> hook
+- "Keep an eye on..." -> cron (polling) + hook (processing), or heartbeat for lighter awareness
+- "Run this every hour and alert me if..." -> cron triggers a hook
+
+## Enabling and Configuration
+
+Hooks require explicit enablement. The HTTP server does not start unless configured.
+
+To enable hooks: `config(action="set", path="hooks.enabled", value="true")` — then restart to apply (warm reload).
+
+Configuration options:
+- `hooks.enabled` (bool, default: false) — start the hooks HTTP server
+- `hooks.port` (int, default: 18791) — HTTP server port
+- `hooks.rateLimitPerHook` (int, default: 60) — max triggers per hook per minute
+- `hooks.maxPayloadBytes` (int, default: 65536) — max POST body size in bytes
+
+The server listens on all interfaces by default. The health endpoint is at `GET /hooks/health` — returns `{"status": "ok"}` when the server is running.
+
+When a user asks to create a hook and hooks are not enabled, enable them first, then restart, then proceed with hook creation. Inform the user that hooks have been enabled.
+
+## Troubleshooting
+
+**Hook not responding (connection refused)**:
+- Hooks not enabled: check `config(action="get", path="hooks.enabled")`
+- Wrong port: check `config(action="get", path="hooks.port")`
+- Agent not running: the hooks server runs as part of the main agent process
+
+**HTTP 404 (not found)**:
+- Wrong hook ID in the URL
+- Hook was deleted
+- Hook is disabled (disabled hooks return 404)
+
+**HTTP 413 (payload too large)**:
+- Payload exceeds `maxPayloadBytes` (default 64KB)
+- Solution: increase the limit or send less data (reference files by path instead)
+
+**HTTP 429 (rate limited)**:
+- Hook exceeded `rateLimitPerHook` triggers in the last minute (default 60)
+- Solution: reduce trigger frequency or increase the limit
+
+**Hook triggers but nothing is delivered**:
+- Mode is "silent" and instructions don't explicitly call for delivery
+- Instructions don't cover the payload's conditions (handler decided not to deliver)
+- Handler errored before reaching deliver_result — check `hook(action="history", id="...")` for error status
+- Check the trigger log at `~/.ragnarbot/hooks/logs/{hook_id}.jsonl` for details
+
+**Handler behaves unexpectedly**:
+- Instructions are the ONLY context — the handler has no conversation history
+- Review instructions for ambiguity or missing payload field descriptions
+- Use `hook(action="update", id="...", instructions="...")` to refine
+
+## Security
+
+- **Hook ID = secret.** The ID is a cryptographic token (`hk_` + 32 bytes URL-safe base64). Knowing it grants trigger access. Treat it like an API key.
+- **Never expose hook IDs** in logs, commits, public repos, or chat messages shared externally.
+- **Store securely**: environment variables, `.env` files (gitignored), CI/CD secrets managers.
+- **Local by default**: the server listens on localhost. Triggers from external systems require a tunnel.
+- **Tunnel setup for external access**: use `ngrok http 18791`, `cloudflared tunnel`, or SSH port forwarding. The tunnel URL becomes the trigger URL base.
+- **Instructions are private**: the triggering script never sees the hook's instructions. Only the agent sees them. This means instructions can contain sensitive logic, internal thresholds, or references to private files.
+- **Rate limiting is per-hook**: each hook has its own sliding window rate limit. One hook being hammered does not affect others.
+- **Rotation**: if a hook ID is compromised, delete the hook and create a new one. Update all trigger scripts with the new ID.

--- a/ragnarbot/skills/hooks/SKILL.md
+++ b/ragnarbot/skills/hooks/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: hooks
+description: Guide for creating and managing webhook hooks — event-driven HTTP endpoints that let external scripts trigger the agent. Use when the user wants to set up hooks, write trigger scripts, or design hook-based automation.
+---
+
+# Hooks
+
+Hooks are event-driven HTTP endpoints. External scripts decide WHEN to trigger; the agent decides WHAT to do. This is the opposite of cron (polling) — hooks are reactive.
+
+## How Hooks Work
+
+1. You create a hook with `hook(action="create", name="...", instructions="...")`.
+2. The tool returns a **hook ID** (which is also the URL path and auth secret).
+3. An external script sends `POST /hooks/{hook_id}` with a payload.
+4. The gateway spawns an isolated agent session with the hook's instructions + the payload.
+5. The session processes the payload and optionally delivers a result to the user's chat.
+
+The hook ID is a long cryptographic token — knowing it grants trigger access. Treat it like a secret.
+
+## Writing Instructions
+
+Instructions are the system prompt for the isolated handler session. They must be **self-contained** — the handler has no conversation history and no knowledge of the user beyond workspace files.
+
+Good instructions include:
+
+- **What data arrives**: "You'll receive a JSON payload with `event`, `repo`, and `message` fields."
+- **What to do**: "Summarize the event and deliver it to the user."
+- **When to deliver**: "Only deliver if the event type is 'failure' or 'critical'."
+- **Format**: "Format as a short alert with emoji indicators."
+
+### Conditional delivery
+
+The most powerful pattern — the handler decides whether to alert:
+
+```
+You'll receive a JSON payload from a CI/CD pipeline.
+
+If the build status is "failed" or "error":
+  - Deliver a concise alert with the repo name, branch, and error summary.
+
+If the build status is "success":
+  - Do NOT deliver. The trigger will be logged silently.
+
+If the payload contains a "rollback" field:
+  - Always deliver, regardless of status. Include the rollback reason.
+```
+
+### History-aware hooks
+
+The handler can read previous trigger logs to detect patterns:
+
+```
+You'll receive server metrics as JSON (cpu, memory, disk, latency).
+
+Use file_read to check the last 5 entries in the hook's log file at
+{workspace}/hooks/logs/{hook_id}.jsonl.
+
+If CPU > 90% for 3+ consecutive triggers, deliver an alert.
+If memory usage increased by more than 20% since the previous trigger, deliver a warning.
+Otherwise, do not deliver.
+```
+
+## Generating Trigger Scripts
+
+When the user asks to set up a hook end-to-end, create both the hook AND the trigger script.
+
+### curl (simplest)
+
+```bash
+#!/bin/bash
+HOOK_URL="http://localhost:18791/hooks/hk_abc123..."
+
+# Example: send JSON payload
+curl -s -X POST "$HOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"event": "deploy", "status": "success", "repo": "myapp"}'
+```
+
+### Python
+
+```python
+import requests
+
+HOOK_URL = "http://localhost:18791/hooks/hk_abc123..."
+
+payload = {"event": "deploy", "status": "success"}
+resp = requests.post(HOOK_URL, json=payload)
+print(resp.status_code, resp.json())
+```
+
+### Scheduling triggers externally
+
+Hook scripts can be scheduled with any external mechanism:
+
+- **crontab**: `*/5 * * * * /path/to/trigger_script.sh` — every 5 minutes
+- **launchd** (macOS): plist with `StartInterval`
+- **systemd timer** (Linux): `.timer` unit
+- **fswatch/inotifywait**: trigger on file changes
+- **CI/CD webhooks**: GitHub Actions, GitLab CI, etc.
+
+## Security
+
+- The hook ID IS the secret. Never expose it in logs, commits, or public repos.
+- Store the hook ID in an environment variable or a secrets file, not hardcoded in scripts.
+- The hooks server only listens locally by default. For external access, use a tunnel (ngrok, cloudflared, SSH tunnel).
+- Each hook has independent rate limiting.
+
+## Patterns
+
+### Alert hook
+The default pattern. Every trigger delivers a message to the user.
+- Mode: `alert`
+- Instructions: "Summarize the payload and deliver it."
+- Use for: notifications, CI alerts, monitoring
+
+### Silent hook
+Triggers are logged but nothing is delivered.
+- Mode: `silent`
+- Instructions: "Process the payload and save results to a file."
+- Use for: data collection, logging, background sync
+
+### Conditional hook
+The handler inspects the payload and decides whether to deliver.
+- Mode: `alert` (handler can choose not to call `deliver_result`)
+- Instructions include conditional logic
+- Use for: smart monitoring, threshold-based alerts, deduplication
+
+### Action hook
+The handler doesn't just alert — it takes action (runs commands, edits files, makes API calls) and then reports what it did.
+- Mode: `alert`
+- Instructions: "If the payload indicates a failing health check, restart the service via exec, then deliver the result."
+- Use for: auto-remediation, automated workflows
+
+## Relationship to Cron and Heartbeat
+
+- **Cron**: polling — the agent runs tasks on a schedule. Best for "do X every N minutes."
+- **Heartbeat**: periodic context check — the agent reviews tasks on an interval. Best for ongoing awareness.
+- **Hooks**: reactive — external events trigger the agent. Best for "when X happens, do Y."
+
+These complement each other:
+- A cron job can run a script that triggers a hook (scheduled event-driven processing).
+- A hook can create/modify cron jobs (event triggers recurring monitoring).
+- Heartbeat provides context; hooks provide events; cron provides schedules.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -282,3 +282,128 @@ async def test_hook_tool_history(hook_service):
     result = await tool.execute(action="history", id=hook.id)
     assert "triggers" in result.lower()
     assert "ok" in result
+
+
+# ========== HTTP Server ==========
+
+
+@pytest.fixture
+async def hook_server(hook_service):
+    from ragnarbot.hooks.server import HookServer
+
+    server = HookServer(
+        service=hook_service,
+        host="127.0.0.1",
+        port=0,  # let OS pick a free port
+        max_payload_bytes=1024,
+        rate_limit_per_hook=5,
+    )
+    # aiohttp needs a real port — use AppRunner manually
+    from aiohttp import web
+    server._runner = web.AppRunner(server.app)
+    await server._runner.setup()
+    site = web.TCPSite(server._runner, "127.0.0.1", 0)
+    await site.start()
+    # Extract the actual port
+    actual_port = site._server.sockets[0].getsockname()[1]
+    server._actual_port = actual_port
+    yield server
+    await server._runner.cleanup()
+
+
+def _base_url(server) -> str:
+    return f"http://127.0.0.1:{server._actual_port}"
+
+
+@pytest.mark.asyncio
+async def test_server_health(hook_server):
+    import aiohttp
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{_base_url(hook_server)}/hooks/health") as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_server_trigger_valid_hook(hook_server, hook_service):
+    import aiohttp
+
+    triggered = []
+    hook_service.on_trigger = lambda hook, payload: _capture(triggered, hook, payload)
+
+    hook = hook_service.add_hook("test-hook", "do stuff", channel="tg", to="123")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{_base_url(hook_server)}/hooks/{hook.id}",
+            json={"event": "test"},
+        ) as resp:
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_server_trigger_unknown_hook(hook_server):
+    import aiohttp
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{_base_url(hook_server)}/hooks/hk_nonexistent",
+            data="test",
+        ) as resp:
+            assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_server_trigger_disabled_hook(hook_server, hook_service):
+    import aiohttp
+    hook = hook_service.add_hook("disabled", "inst")
+    hook_service.update_hook(hook.id, enabled=False)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{_base_url(hook_server)}/hooks/{hook.id}",
+            data="test",
+        ) as resp:
+            assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_server_payload_too_large(hook_server, hook_service):
+    import aiohttp
+    hook = hook_service.add_hook("big", "inst")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{_base_url(hook_server)}/hooks/{hook.id}",
+            data="x" * 2048,  # exceeds max_payload_bytes=1024
+        ) as resp:
+            assert resp.status == 413
+
+
+@pytest.mark.asyncio
+async def test_server_rate_limiting(hook_server, hook_service):
+    import aiohttp
+    hook = hook_service.add_hook("rated", "inst")
+
+    async with aiohttp.ClientSession() as session:
+        # Send 5 requests (the limit)
+        for _ in range(5):
+            async with session.post(
+                f"{_base_url(hook_server)}/hooks/{hook.id}",
+                data="ok",
+            ) as resp:
+                assert resp.status == 202
+
+        # 6th request should be rate limited
+        async with session.post(
+            f"{_base_url(hook_server)}/hooks/{hook.id}",
+            data="one more",
+        ) as resp:
+            assert resp.status == 429
+
+
+async def _capture(triggered, hook, payload):
+    """Helper for capturing trigger calls."""
+    triggered.append((hook.name, payload))

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,284 @@
+"""Tests for the hooks subsystem."""
+
+import json
+
+import pytest
+
+from ragnarbot.hooks.service import HookService, _generate_hook_id
+from ragnarbot.hooks.types import HookDefinition, HookStore
+
+# ========== Types ==========
+
+
+def test_hook_definition_defaults():
+    hook = HookDefinition(id="hk_test", name="test", instructions="do stuff")
+    assert hook.mode == "alert"
+    assert hook.enabled is True
+    assert hook.trigger_count == 0
+    assert hook.channel is None
+    assert hook.to is None
+
+
+def test_hook_store_defaults():
+    store = HookStore()
+    assert store.version == 1
+    assert store.hooks == []
+
+
+# ========== ID Generation ==========
+
+
+def test_hook_id_format():
+    hid = _generate_hook_id()
+    assert hid.startswith("hk_")
+    assert len(hid) > 20  # cryptographic token should be long
+
+
+def test_hook_id_uniqueness():
+    ids = {_generate_hook_id() for _ in range(100)}
+    assert len(ids) == 100
+
+
+# ========== Service CRUD ==========
+
+
+@pytest.fixture
+def hook_service(tmp_path):
+    store_path = tmp_path / "hooks.json"
+    logs_dir = tmp_path / "logs"
+    return HookService(store_path, logs_dir)
+
+
+def test_add_hook(hook_service):
+    hook = hook_service.add_hook(
+        name="CI alerts",
+        instructions="Summarize the CI payload.",
+        mode="alert",
+        channel="telegram",
+        to="12345",
+    )
+    assert hook.name == "CI alerts"
+    assert hook.instructions == "Summarize the CI payload."
+    assert hook.mode == "alert"
+    assert hook.id.startswith("hk_")
+    assert hook.channel == "telegram"
+    assert hook.to == "12345"
+    assert hook.created_at_ms > 0
+
+
+def test_get_hook(hook_service):
+    hook = hook_service.add_hook("test", "instructions")
+    found = hook_service.get_hook(hook.id)
+    assert found is not None
+    assert found.name == "test"
+
+
+def test_get_hook_not_found(hook_service):
+    assert hook_service.get_hook("nonexistent") is None
+
+
+def test_list_hooks(hook_service):
+    hook_service.add_hook("a", "inst a")
+    hook_service.add_hook("b", "inst b")
+    hooks = hook_service.list_hooks()
+    assert len(hooks) == 2
+
+
+def test_list_hooks_excludes_disabled(hook_service):
+    h = hook_service.add_hook("a", "inst")
+    hook_service.update_hook(h.id, enabled=False)
+    assert len(hook_service.list_hooks(include_disabled=False)) == 0
+    assert len(hook_service.list_hooks(include_disabled=True)) == 1
+
+
+def test_update_hook(hook_service):
+    hook = hook_service.add_hook("old", "old inst")
+    updated = hook_service.update_hook(
+        hook.id, name="new", instructions="new inst", mode="silent",
+    )
+    assert updated is not None
+    assert updated.name == "new"
+    assert updated.instructions == "new inst"
+    assert updated.mode == "silent"
+
+
+def test_update_hook_not_found(hook_service):
+    assert hook_service.update_hook("nonexistent", name="x") is None
+
+
+def test_delete_hook(hook_service):
+    hook = hook_service.add_hook("to delete", "inst")
+    assert hook_service.delete_hook(hook.id) is True
+    assert hook_service.get_hook(hook.id) is None
+
+
+def test_delete_hook_not_found(hook_service):
+    assert hook_service.delete_hook("nonexistent") is False
+
+
+def test_increment_trigger_count(hook_service):
+    hook = hook_service.add_hook("test", "inst")
+    assert hook.trigger_count == 0
+    hook_service.increment_trigger_count(hook.id)
+    updated = hook_service.get_hook(hook.id)
+    assert updated.trigger_count == 1
+
+
+# ========== Persistence ==========
+
+
+def test_store_roundtrip(tmp_path):
+    store_path = tmp_path / "hooks.json"
+    logs_dir = tmp_path / "logs"
+
+    svc1 = HookService(store_path, logs_dir)
+    svc1.add_hook("hook1", "instructions1", mode="alert", channel="tg", to="123")
+    svc1.add_hook("hook2", "instructions2", mode="silent")
+
+    # Force reload from disk
+    svc2 = HookService(store_path, logs_dir)
+    hooks = svc2.list_hooks(include_disabled=True)
+    assert len(hooks) == 2
+    assert hooks[0].name == "hook1"
+    assert hooks[0].mode == "alert"
+    assert hooks[0].channel == "tg"
+    assert hooks[1].name == "hook2"
+    assert hooks[1].mode == "silent"
+
+
+def test_store_camel_case_keys(tmp_path):
+    store_path = tmp_path / "hooks.json"
+    logs_dir = tmp_path / "logs"
+
+    svc = HookService(store_path, logs_dir)
+    svc.add_hook("test", "inst")
+
+    data = json.loads(store_path.read_text())
+    hook_data = data["hooks"][0]
+    assert "createdAtMs" in hook_data
+    assert "updatedAtMs" in hook_data
+    assert "triggerCount" in hook_data
+
+
+# ========== Logging ==========
+
+
+def test_log_trigger(hook_service):
+    hook = hook_service.add_hook("test", "inst")
+    hook_service.log_trigger(
+        hook, '{"event": "test"}', "ok", 1.5, "result text",
+    )
+
+    log_file = hook_service.logs_dir / f"{hook.id}.jsonl"
+    assert log_file.exists()
+
+    entries = hook_service.get_history(hook.id)
+    assert len(entries) == 1
+    assert entries[0]["status"] == "ok"
+    assert entries[0]["duration_s"] == 1.5
+
+
+def test_get_history_limit(hook_service):
+    hook = hook_service.add_hook("test", "inst")
+    for i in range(20):
+        hook_service.log_trigger(hook, f"payload {i}", "ok", 0.1)
+
+    entries = hook_service.get_history(hook.id, limit=5)
+    assert len(entries) == 5
+
+
+def test_get_history_empty(hook_service):
+    assert hook_service.get_history("nonexistent") == []
+
+
+# ========== HookTool ==========
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_create(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    tool.set_context("telegram", "12345")
+
+    result = await tool.execute(
+        action="create",
+        name="CI Monitor",
+        instructions="Summarize CI failures.",
+    )
+    assert "Created hook 'CI Monitor'" in result
+    assert "/hooks/hk_" in result
+    assert "curl" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_create_missing_name(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    tool.set_context("telegram", "12345")
+
+    result = await tool.execute(action="create", instructions="test")
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_create_no_context(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+
+    result = await tool.execute(
+        action="create", name="test", instructions="test",
+    )
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_list(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    tool.set_context("telegram", "12345")
+
+    await tool.execute(action="create", name="Hook A", instructions="inst a")
+    await tool.execute(action="create", name="Hook B", instructions="inst b")
+
+    result = await tool.execute(action="list")
+    assert "Hook A" in result
+    assert "Hook B" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_list_empty(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    result = await tool.execute(action="list")
+    assert "No registered hooks" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_delete(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    tool.set_context("telegram", "12345")
+
+    await tool.execute(action="create", name="To Delete", instructions="inst")
+    hooks = hook_service.list_hooks()
+    hook_id = hooks[0].id
+
+    result = await tool.execute(action="delete", id=hook_id)
+    assert "Deleted hook" in result
+
+
+@pytest.mark.asyncio
+async def test_hook_tool_history(hook_service):
+    from ragnarbot.agent.tools.hook import HookTool
+    tool = HookTool(hook_service)
+    tool.set_context("telegram", "12345")
+
+    await tool.execute(action="create", name="Hist Hook", instructions="inst")
+    hooks = hook_service.list_hooks()
+    hook = hooks[0]
+
+    hook_service.log_trigger(hook, "payload", "ok", 0.5)
+
+    result = await tool.execute(action="history", id=hook.id)
+    assert "triggers" in result.lower()
+    assert "ok" in result


### PR DESCRIPTION
## Summary

- Add hooks — event-driven HTTP endpoints that let external scripts trigger the agent via POST requests, spawning isolated autonomous sessions that process payloads and optionally deliver results to the user's chat
- Hook ID doubles as cryptographic auth secret (no separate token) — knowing the ID grants trigger access, simplifying the API to a single `POST /hooks/{hook_id}` with payload body
- aiohttp-based HTTP server on a dedicated port (default 18791) with per-hook sliding-window rate limiting, payload size enforcement, and graceful port-binding error handling for multi-profile setups
- `HookTool` with 5 actions (create/list/update/delete/history) following the established `CronTool` multi-action pattern, with `set_context` dispatch for session-aware delivery
- `process_hook_isolated()` in AgentLoop — structurally mirrors `process_cron_isolated()`: fresh tool registry, HOOK_ISOLATED.md system prompt with instructions + payload placeholders, deliver_result for output capture, session markers for conversation continuity
- `HookService` with JSON persistence (camelCase keys), JSONL per-hook trigger logging, CRUD operations, and profile-aware storage paths (`~/.ragnarbot[-profile]/hooks/`)
- `HooksConfig` in config schema: enabled (default true), port, rate_limit_per_hook, max_payload_bytes — all with appropriate reload levels
- Comprehensive built-in skill (632 lines): architecture walkthrough, bad-vs-good instruction examples, payload design, production trigger scripts (shell/Python/GitHub Actions/fswatch), self-authoring pattern, 6 hook archetypes (alert, silent, conditional, action, history-aware, multi-hook pipeline), cron/heartbeat relationship guide, troubleshooting, security
- Hooks Protocol section in AGENTS.md instructing the agent to always load the hooks skill before working with hooks
- Gateway wiring: HookService + HookServer lifecycle in `commands.py`, `on_hook_trigger` callback with OutboundMessage delivery and session marker injection
- 32 tests covering types, service CRUD, persistence roundtrip, camelCase serialization, trigger logging, history retrieval, HookTool actions, and 6 HTTP server smoke tests (health, valid trigger, 404, disabled, 413, 429)