### PR TITLE
feat: add Opus 4.7/4.8 and GPT-5.5 models with max reasoning level

### DIFF
--- a/ragnarbot/config/providers.py
+++ b/ragnarbot/config/providers.py
@@ -10,9 +10,14 @@ PROVIDERS = [
         "api_key_url": "https://console.anthropic.com/keys",
         "models": [
             {
-                "id": "anthropic/claude-opus-4-6",
-                "name": "Claude Opus 4.6",
+                "id": "anthropic/claude-opus-4-8",
+                "name": "Claude Opus 4.8",
                 "description": "Most intelligent — agents & coding",
+            },
+            {
+                "id": "anthropic/claude-opus-4-7",
+                "name": "Claude Opus 4.7",
+                "description": "Previous flagship — agents & coding",
             },
             {
                 "id": "anthropic/claude-sonnet-4-6",
@@ -24,22 +29,22 @@ PROVIDERS = [
     {
         "id": "openai",
         "name": "OpenAI",
-        "description": "GPT models (GPT-5.4, GPT-5.2, GPT-5 Mini)",
+        "description": "GPT models (GPT-5.5, GPT-5.4, GPT-5.4 Mini)",
         "api_key_url": "https://platform.openai.com/api-keys",
         "models": [
             {
-                "id": "openai/gpt-5.4",
-                "name": "GPT-5.4",
+                "id": "openai/gpt-5.5",
+                "name": "GPT-5.5",
                 "description": "Latest flagship — best reasoning & coding",
             },
             {
-                "id": "openai/gpt-5.2",
-                "name": "GPT-5.2",
+                "id": "openai/gpt-5.4",
+                "name": "GPT-5.4",
                 "description": "Previous flagship — strong reasoning & coding",
             },
             {
-                "id": "openai/gpt-5-mini",
-                "name": "GPT-5 Mini",
+                "id": "openai/gpt-5.4-mini",
+                "name": "GPT-5.4 Mini",
                 "description": "Fast & affordable",
             },
         ],
@@ -101,9 +106,14 @@ PROVIDERS = [
                 "description": "Strong multilingual reasoning & coding",
             },
             {
-                "id": "openrouter/anthropic/claude-opus-4.6",
-                "name": "Claude Opus 4.6",
+                "id": "openrouter/anthropic/claude-opus-4.8",
+                "name": "Claude Opus 4.8",
                 "description": "Most intelligent — via OpenRouter",
+            },
+            {
+                "id": "openrouter/anthropic/claude-opus-4.7",
+                "name": "Claude Opus 4.7",
+                "description": "Previous flagship — via OpenRouter",
             },
             {
                 "id": "openrouter/anthropic/claude-sonnet-4.6",
@@ -121,14 +131,14 @@ PROVIDERS = [
                 "description": "Best reasoning & coding — via OpenRouter",
             },
             {
-                "id": "openrouter/openai/gpt-5.2",
-                "name": "GPT-5.2",
-                "description": "Previous flagship — via OpenRouter",
+                "id": "openrouter/openai/gpt-5.5",
+                "name": "GPT-5.5",
+                "description": "Latest flagship — via OpenRouter",
             },
             {
                 "id": "openrouter/openai/gpt-5.4",
                 "name": "GPT-5.4",
-                "description": "Latest flagship — via OpenRouter",
+                "description": "Previous flagship — via OpenRouter",
             },
             {
                 "id": "openrouter/google/gemini-3-pro-preview",

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -39,12 +39,12 @@ class AgentDefaults(BaseModel):
         json_schema_extra={"reload": "cold", "label": "Workspace directory path"},
     )
     model: str = Field(
-        default="anthropic/claude-opus-4-6",
+        default="anthropic/claude-opus-4-8",
         json_schema_extra={"reload": "warm", "label": "LLM model identifier (provider/model)"},
     )
     reasoning_level: str = Field(
         default="medium",
-        pattern="^(off|low|medium|high|ultra)$",
+        pattern="^(off|low|medium|high|ultra|max)$",
         json_schema_extra={"reload": "hot", "label": "Unified reasoning level"},
     )
     lightning_mode: bool = Field(

--- a/ragnarbot/providers/anthropic_provider.py
+++ b/ragnarbot/providers/anthropic_provider.py
@@ -7,8 +7,14 @@ from typing import Any
 
 from anthropic import APIStatusError, AsyncAnthropic
 
-from ragnarbot.providers.base import DEFAULT_MAX_TOKENS, LLMProvider, LLMResponse, ToolCallRequest
+from ragnarbot.providers.base import MAX_OUTPUT_TOKENS, LLMProvider, LLMResponse, ToolCallRequest
 from ragnarbot.providers.reasoning import resolve_reasoning
+
+# Anthropic streams every request (see chat()), so it is not bound by the SDK's
+# non-streaming max_tokens ValueError. Default to the full 128k sync-API output
+# ceiling (Claude 4.x) so extended thinking at "max"/"xhigh" effort (Opus 4.7/4.8)
+# is never truncated early. (300k exists but is Batches-API-only.)
+ANTHROPIC_DEFAULT_MAX_TOKENS = MAX_OUTPUT_TOKENS
 
 # Headers required by Anthropic API for OAuth token authentication.
 _OAUTH_HEADERS = {
@@ -41,7 +47,7 @@ class AnthropicProvider(LLMProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        default_model: str = "claude-opus-4-6",
+        default_model: str = "claude-opus-4-8",
         oauth_token: str | None = None,
     ):
         super().__init__(api_key, oauth_token)
@@ -90,7 +96,7 @@ class AnthropicProvider(LLMProvider):
         _ = lightning_mode
         model = model or self.default_model
         reasoning = resolve_reasoning(model, reasoning_level)
-        max_tokens = max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS
+        max_tokens = max_tokens if max_tokens is not None else ANTHROPIC_DEFAULT_MAX_TOKENS
         # Strip provider prefix — config stores "anthropic/claude-...", SDK expects "claude-..."
         if model.startswith("anthropic/"):
             model = model[len("anthropic/"):]

--- a/ragnarbot/providers/base.py
+++ b/ragnarbot/providers/base.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 DEFAULT_MAX_TOKENS = 32_000
+# Synchronous-API output ceiling for current OpenAI GPT-5.x and Anthropic Claude 4.x
+# models (both cap a single response at 128k tokens). Used as the default response
+# budget for those providers so long generations are not truncated early.
+MAX_OUTPUT_TOKENS = 128_000
 
 
 @dataclass
@@ -100,7 +104,7 @@ class LLMProvider(ABC):
             model: Model identifier (provider-specific).
             max_tokens: Maximum tokens in response (defaults to DEFAULT_MAX_TOKENS).
             temperature: Sampling temperature (omitted if None — uses API default).
-            reasoning_level: Unified reasoning level (off/low/medium/high/ultra).
+            reasoning_level: Unified reasoning level (off/low/medium/high/ultra/max).
             lightning_mode: Whether OpenAI Lightning Mode is enabled for this request.
             session_key: Stable conversation identifier for stateful transports.
             tool_runner: Optional host-side tool executor for transports that

--- a/ragnarbot/providers/lightning.py
+++ b/ragnarbot/providers/lightning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 LIGHTNING_SUPPORTED_MODELS = frozenset({
+    "openai/gpt-5.5",
     "openai/gpt-5.4",
 })
 LIGHTNING_SUPPORTED_AUTH_METHODS = frozenset({

--- a/ragnarbot/providers/litellm_provider.py
+++ b/ragnarbot/providers/litellm_provider.py
@@ -7,7 +7,13 @@ import litellm
 from litellm import acompletion
 from loguru import logger
 
-from ragnarbot.providers.base import DEFAULT_MAX_TOKENS, LLMProvider, LLMResponse, ToolCallRequest
+from ragnarbot.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    MAX_OUTPUT_TOKENS,
+    LLMProvider,
+    LLMResponse,
+    ToolCallRequest,
+)
 from ragnarbot.providers.lightning import resolve_lightning
 from ragnarbot.providers.reasoning import resolve_reasoning
 
@@ -76,7 +82,11 @@ class LiteLLMProvider(LLMProvider):
         model = model or self.default_model
         reasoning = resolve_reasoning(model, reasoning_level)
         lightning = resolve_lightning(model, "api_key", lightning_mode)
-        max_tokens = max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS
+        if max_tokens is None:
+            # OpenAI GPT-5.x accepts up to 128k output tokens; Gemini/OpenRouter
+            # models vary and may reject a value above their own ceiling, so keep
+            # the conservative default for them.
+            max_tokens = MAX_OUTPUT_TOKENS if model.startswith("openai/") else DEFAULT_MAX_TOKENS
 
         is_openrouter = model.startswith("openrouter/")
 

--- a/ragnarbot/providers/reasoning.py
+++ b/ragnarbot/providers/reasoning.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-ReasoningLevel = Literal["off", "low", "medium", "high", "ultra"]
+ReasoningLevel = Literal["off", "low", "medium", "high", "ultra", "max"]
 SUPPORTED_REASONING_LEVELS: tuple[ReasoningLevel, ...] = (
     "off",
     "low",
     "medium",
     "high",
     "ultra",
+    "max",
 )
 
 
@@ -43,10 +44,15 @@ def resolve_reasoning(model: str, reasoning_level: str | None) -> ReasoningResol
     stored_level = normalize_reasoning_level(reasoning_level)
     normalized_model = _normalize_model_id(model)
 
-    if normalized_model in {"openai/gpt-5.4", "openai/gpt-5.2"}:
+    if normalized_model in {
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "openai/gpt-5.4-mini",
+        "openai/gpt-5.2",
+    }:
         return _resolve_openai_flagship(normalized_model, stored_level)
-    if normalized_model == "openai/gpt-5-mini":
-        return _resolve_openai_mini(normalized_model, stored_level)
+    if normalized_model in {"anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7"}:
+        return _resolve_anthropic_47_plus(normalized_model, stored_level)
     if normalized_model in {"anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"}:
         return _resolve_anthropic_46(normalized_model, stored_level)
     if normalized_model in {"gemini/gemini-3.1-pro-preview", "gemini/gemini-3-pro-preview"}:
@@ -82,45 +88,32 @@ def _normalize_model_id(model: str) -> str:
 
 
 def _resolve_openai_flagship(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
+    # OpenAI flagship models top out at xhigh — they have no "max" effort, so the
+    # unified "max" level clamps down to xhigh (same as "ultra").
     effort_map = {
         "off": "none",
         "low": "low",
         "medium": "medium",
         "high": "high",
+        "ultra": "xhigh",
+        "max": "xhigh",
     }
-    if stored_level == "ultra":
-        return ReasoningResolution(
-            model=model,
-            stored_level=stored_level,
-            effective_level="ultra",
-            reasoning_effort="xhigh",
-            openai_reasoning={"effort": "xhigh"},
-        )
-
+    effort = effort_map[stored_level]
+    note = "This model maps max to xhigh." if stored_level == "max" else None
+    effective_level: ReasoningLevel = "ultra" if stored_level == "max" else stored_level
     return ReasoningResolution(
         model=model,
         stored_level=stored_level,
-        effective_level=stored_level,
-        reasoning_effort=effort_map[stored_level],
-        openai_reasoning={"effort": effort_map[stored_level]},
-    )
-
-
-def _resolve_openai_mini(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
-    note = None
-    if stored_level != "medium":
-        note = "This model uses a fixed medium reasoning level."
-    return ReasoningResolution(
-        model=model,
-        stored_level=stored_level,
-        effective_level="medium",
+        effective_level=effective_level,
         note=note,
-        reasoning_effort="medium",
-        openai_reasoning={"effort": "medium"},
+        reasoning_effort=effort,
+        openai_reasoning={"effort": effort},
     )
 
 
-def _resolve_anthropic_46(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
+def _resolve_anthropic_47_plus(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
+    # Opus 4.7/4.8 add the "xhigh" effort rung (between high and max) and default
+    # thinking.display to "omitted" — set "summarized" so thinking stays visible.
     if stored_level == "off":
         return ReasoningResolution(
             model=model,
@@ -130,7 +123,35 @@ def _resolve_anthropic_46(model: str, stored_level: ReasoningLevel) -> Reasoning
             anthropic_output_config=None,
         )
 
-    if stored_level == "ultra" and model != "anthropic/claude-opus-4-6":
+    effort_map = {
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "ultra": "xhigh",
+        "max": "max",
+    }
+    return ReasoningResolution(
+        model=model,
+        stored_level=stored_level,
+        effective_level=stored_level,
+        anthropic_thinking={"type": "adaptive", "display": "summarized"},
+        anthropic_output_config={"effort": effort_map[stored_level]},
+    )
+
+
+def _resolve_anthropic_46(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
+    # Opus/Sonnet 4.6 support {low, medium, high, max} but not xhigh — the unified
+    # "ultra" (xhigh) tier clamps down to high, while "max" reaches the true max.
+    if stored_level == "off":
+        return ReasoningResolution(
+            model=model,
+            stored_level=stored_level,
+            effective_level="off",
+            anthropic_thinking=None,
+            anthropic_output_config=None,
+        )
+
+    if stored_level == "ultra":
         return ReasoningResolution(
             model=model,
             stored_level=stored_level,
@@ -141,17 +162,16 @@ def _resolve_anthropic_46(model: str, stored_level: ReasoningLevel) -> Reasoning
         )
 
     effort_map = {
-        "off": "low",
         "low": "low",
         "medium": "medium",
         "high": "high",
-        "ultra": "max",
+        "max": "max",
     }
     return ReasoningResolution(
         model=model,
         stored_level=stored_level,
         effective_level=stored_level,
-        anthropic_thinking=None if stored_level == "off" else {"type": "adaptive"},
+        anthropic_thinking={"type": "adaptive"},
         anthropic_output_config={"effort": effort_map[stored_level]},
     )
 
@@ -186,9 +206,16 @@ def _resolve_gemini_flash(model: str, stored_level: ReasoningLevel) -> Reasoning
         "medium": "medium",
         "high": "high",
         "ultra": "high",
+        "max": "high",
     }
-    effective_level: ReasoningLevel = "high" if stored_level == "ultra" else stored_level
-    note = "This model maps ultra to high." if stored_level == "ultra" else None
+    effective_level: ReasoningLevel = (
+        "high" if stored_level in {"ultra", "max"} else stored_level
+    )
+    note = (
+        f"This model maps {stored_level} to high."
+        if stored_level in {"ultra", "max"}
+        else None
+    )
 
     return ReasoningResolution(
         model=model,
@@ -212,15 +239,17 @@ def _resolve_openrouter(model: str, stored_level: ReasoningLevel) -> ReasoningRe
             openrouter_reasoning={"enabled": False},
         )
 
+    # OpenRouter effort tops out at xhigh, so the unified "max" clamps to xhigh.
     effort_map = {
         "low": "low",
         "medium": "medium",
         "high": "high",
         "ultra": "xhigh",
+        "max": "xhigh",
     }
-    effective_level: ReasoningLevel = stored_level
-    note = None
-    if stored_level == "ultra" and model in {
+    effective_level: ReasoningLevel = "ultra" if stored_level == "max" else stored_level
+    note = "OpenRouter maps max to xhigh." if stored_level == "max" else None
+    if stored_level in {"ultra", "max"} and model in {
         "openrouter/google/gemini-3-pro-preview",
         "openrouter/google/gemini-3.1-pro-preview",
         "openrouter/google/gemini-3-flash-preview",

--- a/ragnarbot/skills/agent-creator/SKILL.md
+++ b/ragnarbot/skills/agent-creator/SKILL.md
@@ -47,7 +47,7 @@ agent-name/
 - **name** — Agent identifier. Must match the directory name. Kebab-case, lowercase.
 - **description** — What the agent does. Shown in the agents summary so the main agent knows when to spawn it. Be specific about the agent's specialty and output format.
 - **model** — `default` (inherits from config) or explicit like `anthropic/claude-sonnet-4.6`. Only override when a specific model is genuinely better for the task.
-- **reasoningLevel** — `inherit` (default, use the parent/global reasoning level) or one of `off`, `low`, `medium`, `high`, `ultra`. Use this only when the agent should consistently run with a different reasoning budget than its parent.
+- **reasoningLevel** — `inherit` (default, use the parent/global reasoning level) or one of `off`, `low`, `medium`, `high`, `ultra`, `max`. Use this only when the agent should consistently run with a different reasoning budget than its parent.
 - **allowedTools** — `all` (gets all safe tools) or explicit list like `[web_search, web_fetch, browser]`. Available safe tools: `file_read`, `file_write`, `file_edit`, `list_dir`, `exec`, `web_search`, `web_fetch`, `browser`, `exec_bg`, `poll`, `output`, `kill`, `dismiss`. Use `[]` for agents that need no tools.
 - **allowedSkills** — `none` (default, no skills), `all` (every available skill), or explicit list like `[agent-creator, prompt-engineering]`. When skills are allowed, the agent receives a skills summary in its prompt and can use `file_read` to load the full SKILL.md on demand. `file_read` is automatically added to the agent's tools when any skills are allowed, even if not listed in `allowedTools`.
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -431,7 +431,7 @@ async def test_subagent_inherits_parent_reasoning_level_and_keeps_its_model(tmp_
     await loop.subagents._run_agent(
         task,
         definition=None,
-        model="openai/gpt-5-mini",
+        model="openai/gpt-5.4-mini",
         tools=tools,
         deliver_tool=deliver_tool,
     )
@@ -439,7 +439,7 @@ async def test_subagent_inherits_parent_reasoning_level_and_keeps_its_model(tmp_
     call_kwargs = provider.chat.await_args.kwargs
     assert call_kwargs["reasoning_level"] == "ultra"
     assert call_kwargs["lightning_mode"] is False
-    assert call_kwargs["model"] == "openai/gpt-5-mini"
+    assert call_kwargs["model"] == "openai/gpt-5.4-mini"
 
 
 @pytest.mark.asyncio
@@ -1241,7 +1241,7 @@ class TestCronIsolatedAgentProfile:
         d.mkdir(parents=True)
         (d / "AGENT.md").write_text(
             "---\nname: researcher\ndescription: Research\n"
-            "model: openai/gpt-5-mini\nreasoningLevel: low\n---\nDo work.",
+            "model: openai/gpt-5.4-mini\nreasoningLevel: low\n---\nDo work.",
             encoding="utf-8",
         )
         loader = AgentsLoader(tmp_path / "workspace", builtin_agents_dir=builtin)
@@ -1260,7 +1260,7 @@ class TestCronIsolatedAgentProfile:
 
         assert result == "done"
         call_kwargs = loop.provider.chat.await_args.kwargs
-        assert call_kwargs["model"] == "openai/gpt-5-mini"
+        assert call_kwargs["model"] == "openai/gpt-5.4-mini"
         assert call_kwargs["reasoning_level"] == "low"
         assert OPENAI_STYLE_ADDENDUM in call_kwargs["messages"][0]["content"]
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -118,7 +118,7 @@ class TestOnboardingFlow:
 
         assert mock_save_config.called
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "anthropic/claude-opus-4-6"
+        assert config.agents.defaults.model == "anthropic/claude-opus-4-8"
         assert config.agents.defaults.auth_method == "api_key"
 
         assert mock_save_creds.called
@@ -132,6 +132,7 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select OAuth (first option)
             *[(Key.CHAR, c) for c in "oauth-token-xyz"],
             (Key.ENTER, ""),        # Confirm token
+            (Key.DOWN, ""),         # Navigate past Opus 4.7
             (Key.DOWN, ""),         # Navigate to Sonnet
             (Key.ENTER, ""),        # Select Sonnet
             *SKIP_LIGHTNING,
@@ -162,7 +163,7 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select API Key
             *[(Key.CHAR, c) for c in "sk-openai-key"],
             (Key.ENTER, ""),        # Confirm key
-            (Key.ENTER, ""),        # Select first model (GPT-5.4)
+            (Key.ENTER, ""),        # Select first model (GPT-5.5)
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
             (Key.DOWN, ""),         # Voice: past ElevenLabs
@@ -176,7 +177,7 @@ class TestOnboardingFlow:
         mock_save_config, mock_save_creds = self._run_with_keys(keys, tmp_path)
 
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "openai/gpt-5.4"
+        assert config.agents.defaults.model == "openai/gpt-5.5"
         assert config.agents.defaults.auth_method == "api_key"
         assert config.agents.defaults.lightning_mode is True
 
@@ -189,7 +190,7 @@ class TestOnboardingFlow:
             (Key.DOWN, ""),         # Navigate to OpenAI
             (Key.ENTER, ""),        # Select OpenAI
             (Key.ENTER, ""),        # Select OAuth
-            (Key.ENTER, ""),        # Select first model (GPT-5.4)
+            (Key.ENTER, ""),        # Select first model (GPT-5.5)
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Acknowledge Codex CLI required
         ]
@@ -217,7 +218,7 @@ class TestOnboardingFlow:
             run_onboarding(con)
 
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "openai/gpt-5.4"
+        assert config.agents.defaults.model == "openai/gpt-5.5"
         assert config.agents.defaults.auth_method == "oauth"
         assert config.agents.defaults.lightning_mode is False
         assert mock_save_creds.called

--- a/tests/test_openai_chatgpt_provider.py
+++ b/tests/test_openai_chatgpt_provider.py
@@ -329,7 +329,7 @@ async def test_provider_keeps_raw_path_for_non_gpt_5_4_models():
     ):
         response = await provider.chat(
             messages=[{"role": "user", "content": "hi"}],
-            model="openai/gpt-5-mini",
+            model="openai/gpt-5.4-mini",
             lightning_mode=True,
             session_key="telegram:123",
             tool_runner=AsyncMock(return_value="ok"),

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -47,31 +47,36 @@ def test_get_provider_not_found():
 
 def test_get_models_returns_list():
     models = get_models("anthropic")
-    assert len(models) == 2
-    assert models[0]["id"] == "anthropic/claude-opus-4-6"
+    assert len(models) == 3
+    assert models[0]["id"] == "anthropic/claude-opus-4-8"
 
 
-def test_anthropic_registry_drops_4_5_models():
+def test_anthropic_registry_drops_older_models():
     model_ids = [m["id"] for m in get_models("anthropic")]
     assert "anthropic/claude-sonnet-4-5" not in model_ids
     assert "anthropic/claude-haiku-4-5" not in model_ids
+    assert "anthropic/claude-opus-4-6" not in model_ids
+    assert "anthropic/claude-opus-4-8" in model_ids
+    assert "anthropic/claude-opus-4-7" in model_ids
 
 
-def test_openai_models_include_gpt_5_4_first():
+def test_openai_models_include_gpt_5_5_first():
     models = get_models("openai")
     model_ids = [m["id"] for m in models]
 
-    assert models[0]["id"] == "openai/gpt-5.4"
-    assert "openai/gpt-5.2" in model_ids
-    assert "openai/gpt-5-mini" in model_ids
+    assert models[0]["id"] == "openai/gpt-5.5"
+    assert "openai/gpt-5.4" in model_ids
+    assert "openai/gpt-5.2" not in model_ids
+    assert "openai/gpt-5.4-mini" in model_ids
 
 
-def test_openrouter_models_include_gpt_5_4():
+def test_openrouter_models_include_gpt_5_5():
     models = get_models("openrouter")
     model_ids = [m["id"] for m in models]
 
+    assert "openrouter/openai/gpt-5.5" in model_ids
     assert "openrouter/openai/gpt-5.4" in model_ids
-    assert "openrouter/openai/gpt-5.2" in model_ids
+    assert "openrouter/openai/gpt-5.2" not in model_ids
 
 
 def test_gemini_models_include_3_1_pro_first():

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -64,9 +64,9 @@ def test_resolve_reasoning_covers_expected_downgrades():
     assert openai_flagship.effective_level == "ultra"
     assert openai_flagship.openai_reasoning == {"effort": "xhigh"}
 
-    openai_mini = resolve_reasoning("openai/gpt-5-mini", "off")
-    assert openai_mini.effective_level == "medium"
-    assert openai_mini.note is not None
+    openai_mini = resolve_reasoning("openai/gpt-5.4-mini", "ultra")
+    assert openai_mini.effective_level == "ultra"
+    assert openai_mini.openai_reasoning == {"effort": "xhigh"}
 
     gemini_pro = resolve_reasoning("gemini/gemini-3.1-pro-preview", "medium")
     assert gemini_pro.effective_level == "high"
@@ -82,9 +82,10 @@ def test_resolve_reasoning_covers_expected_downgrades():
     assert openrouter_gemini.openrouter_reasoning == {"enabled": True, "effort": "xhigh"}
 
     anthropic = resolve_reasoning("anthropic/claude-opus-4-6", "ultra")
-    assert anthropic.effective_level == "ultra"
+    assert anthropic.effective_level == "high"
+    assert anthropic.note == "This model maps ultra to high."
     assert anthropic.anthropic_thinking == {"type": "adaptive"}
-    assert anthropic.anthropic_output_config == {"effort": "max"}
+    assert anthropic.anthropic_output_config == {"effort": "high"}
 
     anthropic_off = resolve_reasoning("anthropic/claude-opus-4-6", "off")
     assert anthropic_off.effective_level == "off"
@@ -98,6 +99,61 @@ def test_resolve_reasoning_covers_expected_downgrades():
     assert anthropic_sonnet.anthropic_output_config == {"effort": "high"}
 
 
+def test_resolve_reasoning_opus_47_plus_exposes_xhigh_and_max():
+    for model in ("anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7"):
+        ultra = resolve_reasoning(model, "ultra")
+        assert ultra.effective_level == "ultra"
+        assert ultra.anthropic_thinking == {"type": "adaptive", "display": "summarized"}
+        assert ultra.anthropic_output_config == {"effort": "xhigh"}
+
+        mx = resolve_reasoning(model, "max")
+        assert mx.effective_level == "max"
+        assert mx.anthropic_thinking == {"type": "adaptive", "display": "summarized"}
+        assert mx.anthropic_output_config == {"effort": "max"}
+
+        off = resolve_reasoning(model, "off")
+        assert off.effective_level == "off"
+        assert off.anthropic_thinking is None
+        assert off.anthropic_output_config is None
+
+
+def test_resolve_reasoning_max_level_across_families():
+    # GPT-5.5 flagship: ultra -> xhigh, max clamps to xhigh (OpenAI has no max).
+    gpt_ultra = resolve_reasoning("openai/gpt-5.5", "ultra")
+    assert gpt_ultra.openai_reasoning == {"effort": "xhigh"}
+    gpt_max = resolve_reasoning("openai/gpt-5.5", "max")
+    assert gpt_max.effective_level == "ultra"
+    assert gpt_max.openai_reasoning == {"effort": "xhigh"}
+    assert gpt_max.note == "This model maps max to xhigh."
+
+    # 4.6 models lack xhigh: max reaches the true max effort.
+    sonnet_max = resolve_reasoning("anthropic/claude-sonnet-4-6", "max")
+    assert sonnet_max.effective_level == "max"
+    assert sonnet_max.anthropic_output_config == {"effort": "max"}
+
+    # Gemini Flash bins max down to high.
+    flash_max = resolve_reasoning("gemini/gemini-3-flash-preview", "max")
+    assert flash_max.effective_level == "high"
+    assert flash_max.note == "This model maps max to high."
+    assert flash_max.gemini_thinking_config["thinkingLevel"] == "HIGH"
+
+    # OpenRouter clamps max to xhigh.
+    openrouter_max = resolve_reasoning("openrouter/openai/gpt-5.5", "max")
+    assert openrouter_max.openrouter_reasoning == {"enabled": True, "effort": "xhigh"}
+    assert openrouter_max.note == "OpenRouter maps max to xhigh."
+
+
+def test_reasoning_level_max_roundtrips(tmp_path):
+    config = Config()
+    config.agents.defaults.reasoning_level = "max"
+
+    config_path = tmp_path / "config.json"
+    save_config(config, config_path)
+
+    loaded = load_config(config_path)
+    assert loaded.agents.defaults.reasoning_level == "max"
+
+
 def test_resolve_lightning_support_matrix():
     supported = resolve_lightning("openai/gpt-5.4", "api_key", True)
     assert supported.supported is True
@@ -109,7 +165,7 @@ def test_resolve_lightning_support_matrix():
     assert oauth.applies is True
     assert oauth.service_tier == "priority"
 
-    mini = resolve_lightning("openai/gpt-5-mini", "api_key", True)
+    mini = resolve_lightning("openai/gpt-5.4-mini", "api_key", True)
     assert mini.supported is False
     assert mini.applies is False
 
@@ -121,7 +177,7 @@ def test_resolve_lightning_support_matrix():
 def test_create_provider_uses_native_anthropic_for_api_key():
     creds = MagicMock()
     creds.providers.anthropic.api_key = "sk-ant-test"
-    provider = _create_provider("anthropic/claude-opus-4-6", "api_key", creds)
+    provider = _create_provider("anthropic/claude-opus-4-8", "api_key", creds)
     assert isinstance(provider, AnthropicProvider)
 
 
@@ -156,12 +212,12 @@ def test_openai_build_request_skips_priority_service_tier_for_raw_oauth_lightnin
 
 def test_openai_build_request_skips_priority_service_tier_for_unsupported_lightning():
     with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
-        provider = OpenAIChatGPTProvider(default_model="openai/gpt-5-mini")
+        provider = OpenAIChatGPTProvider(default_model="openai/gpt-5.4-mini")
 
     body = provider._build_request(
         messages=[{"role": "user", "content": "hi"}],
         tools=None,
-        model="gpt-5-mini",
+        model="gpt-5.4-mini",
         reasoning_level="medium",
         lightning_mode=True,
     )
@@ -193,7 +249,7 @@ async def test_gemini_chat_includes_thinking_config():
 
 @pytest.mark.asyncio
 async def test_anthropic_chat_includes_reasoning_kwargs():
-    provider = AnthropicProvider(api_key="sk-test", default_model="anthropic/claude-opus-4-6")
+    provider = AnthropicProvider(api_key="sk-test", default_model="anthropic/claude-opus-4-8")
 
     text_block = MagicMock()
     text_block.type = "text"
@@ -213,17 +269,18 @@ async def test_anthropic_chat_includes_reasoning_kwargs():
 
     await provider.chat(
         [{"role": "user", "content": "hi"}],
-        reasoning_level="ultra",
+        reasoning_level="max",
     )
 
     call_kwargs = provider.client.messages.stream.call_args.kwargs
-    assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert call_kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert call_kwargs["output_config"] == {"effort": "max"}
+    assert call_kwargs["max_tokens"] == 128_000
 
 
 @pytest.mark.asyncio
 async def test_litellm_passes_reasoning_effort():
-    provider = LiteLLMProvider(api_key="sk-openai", default_model="openai/gpt-5.2")
+    provider = LiteLLMProvider(api_key="sk-openai", default_model="openai/gpt-5.5")
     mock_acompletion = AsyncMock(return_value=_mock_litellm_response())
 
     with (
@@ -236,6 +293,7 @@ async def test_litellm_passes_reasoning_effort():
         )
 
     assert mock_acompletion.await_args.kwargs["reasoning_effort"] == "xhigh"
+    assert mock_acompletion.await_args.kwargs["max_tokens"] == 128_000
 
 
 @pytest.mark.asyncio
@@ -257,7 +315,7 @@ async def test_litellm_passes_priority_service_tier_for_supported_lightning():
 
 @pytest.mark.asyncio
 async def test_litellm_skips_priority_service_tier_for_unsupported_lightning():
-    provider = LiteLLMProvider(api_key="sk-openai", default_model="openai/gpt-5.2")
+    provider = LiteLLMProvider(api_key="sk-openai", default_model="openai/gpt-5.4-mini")
     mock_acompletion = AsyncMock(return_value=_mock_litellm_response())
 
     with (
@@ -291,3 +349,5 @@ async def test_litellm_openrouter_uses_dynamic_reasoning_body():
 
     extra_body = mock_acompletion.await_args.kwargs["extra_body"]
     assert extra_body["reasoning"] == {"enabled": True, "effort": "xhigh"}
+    # Non-OpenAI models (here OpenRouter) keep the conservative output default.
+    assert mock_acompletion.await_args.kwargs["max_tokens"] == 32_000


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.7/4.8 and GPT-5.5 to the model registry, rename GPT-5 Mini → GPT-5.4 Mini, drop the superseded Opus 4.6 and GPT-5.2, and bump the default model to Opus 4.8. Existing configs pinned to a removed model keep working (grandfathered) — there is no silent migration.
- Extend the unified reasoning scale with a sixth level `max`. Opus 4.7/4.8 expose the new `xhigh` rung (via `ultra`) and `max`; OpenAI/OpenRouter clamp `max` down to `xhigh` and the 4.6 family clamps `ultra` to `high`, each with an explanatory note. GPT-5.4 Mini now uses the full `reasoning_effort` range instead of a fixed level.
- Default OpenAI and Anthropic responses to the 128k synchronous-API output ceiling so long generations (including extended thinking at `max`/`xhigh`) are not truncated early. The Anthropic provider already streams every request, so the SDK's large-`max_tokens` guard never trips; Gemini/OpenRouter keep the conservative default since their ceilings are lower or unconfirmed.
