### PR TITLE
feat: add grep/glob search tools and harden file_read/edit_file

### DIFF
--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -35,6 +35,7 @@ from ragnarbot.agent.tools.hook import HookTool
 from ragnarbot.agent.tools.media import DownloadFileTool
 from ragnarbot.agent.tools.registry import ToolRegistry
 from ragnarbot.agent.tools.restart import RestartTool
+from ragnarbot.agent.tools.search import GlobTool, GrepTool
 from ragnarbot.agent.tools.shell import ExecTool
 from ragnarbot.agent.tools.telegram import (
     SendFileTool,
@@ -75,7 +76,12 @@ from ragnarbot.session.manager import SessionManager
 
 if TYPE_CHECKING:
     from ragnarbot.agent.agents_loader import AgentDefinition
-    from ragnarbot.config.schema import BrowserConfig, ExecToolConfig, FallbackConfig
+    from ragnarbot.config.schema import (
+        BrowserConfig,
+        ExecToolConfig,
+        FallbackConfig,
+        SearchToolConfig,
+    )
     from ragnarbot.cron.service import CronService
     from ragnarbot.hooks.service import HookService
 
@@ -138,6 +144,7 @@ class AgentLoop:
         brave_api_key: str | None = None,
         search_engine: str = "brave",
         exec_config: "ExecToolConfig | None" = None,
+        search_config: "SearchToolConfig | None" = None,
         cron_service: "CronService | None" = None,
         hook_service: "HookService | None" = None,
         stream_steps: bool = False,
@@ -157,7 +164,7 @@ class AgentLoop:
         experimental_soul: bool = False,
         browser_config: "BrowserConfig | None" = None,
     ):
-        from ragnarbot.config.schema import ExecToolConfig
+        from ragnarbot.config.schema import ExecToolConfig, SearchToolConfig
         self.bus = bus
         self.provider = provider
         self.workspace = workspace
@@ -165,6 +172,7 @@ class AgentLoop:
         self.brave_api_key = brave_api_key
         self.search_engine = search_engine
         self.exec_config = exec_config or ExecToolConfig()
+        self.search_config = search_config or SearchToolConfig()
         self.cron_service = cron_service
         self.hook_service = hook_service
         self.stream_steps = stream_steps
@@ -223,6 +231,7 @@ class AgentLoop:
             brave_api_key=brave_api_key,
             search_engine=search_engine,
             exec_config=self.exec_config,
+            search_config=self.search_config,
             chat_fn=self._chat_with_fallback,
             on_fallback_batch=self._record_fallback_batch,
             browser_manager=self.browser_manager,
@@ -256,6 +265,21 @@ class AgentLoop:
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.exec_config.restrict_to_workspace,
             safety_guard=self.exec_config.safety_guard,
+        ))
+
+        # Search tools
+        self.tools.register(GrepTool(
+            workspace=self.workspace,
+            backend=self.search_config.backend,
+            max_matches=self.search_config.max_matches,
+            max_output_chars=self.search_config.max_output_chars,
+            timeout=self.search_config.timeout,
+        ))
+        self.tools.register(GlobTool(
+            workspace=self.workspace,
+            max_results=self.search_config.max_results,
+            max_output_chars=self.search_config.max_output_chars,
+            timeout=self.search_config.timeout,
         ))
 
         # Web tools
@@ -2701,6 +2725,21 @@ class AgentLoop:
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.exec_config.restrict_to_workspace,
             safety_guard=self.exec_config.safety_guard,
+        ))
+
+        # Search
+        reg.register(GrepTool(
+            workspace=self.workspace,
+            backend=self.search_config.backend,
+            max_matches=self.search_config.max_matches,
+            max_output_chars=self.search_config.max_output_chars,
+            timeout=self.search_config.timeout,
+        ))
+        reg.register(GlobTool(
+            workspace=self.workspace,
+            max_results=self.search_config.max_results,
+            max_output_chars=self.search_config.max_output_chars,
+            timeout=self.search_config.timeout,
         ))
 
         # Web

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -274,6 +274,7 @@ class AgentLoop:
             max_matches=self.search_config.max_matches,
             max_output_chars=self.search_config.max_output_chars,
             timeout=self.search_config.timeout,
+            auto_install=self.search_config.auto_install,
         ))
         self.tools.register(GlobTool(
             workspace=self.workspace,
@@ -2734,6 +2735,7 @@ class AgentLoop:
             max_matches=self.search_config.max_matches,
             max_output_chars=self.search_config.max_output_chars,
             timeout=self.search_config.timeout,
+            auto_install=self.search_config.auto_install,
         ))
         reg.register(GlobTool(
             workspace=self.workspace,

--- a/ragnarbot/agent/subagent.py
+++ b/ragnarbot/agent/subagent.py
@@ -597,6 +597,7 @@ class SubagentManager:
                 max_matches=self.search_config.max_matches,
                 max_output_chars=self.search_config.max_output_chars,
                 timeout=self.search_config.timeout,
+                auto_install=self.search_config.auto_install,
             ))
         if "glob" in allowed:
             reg.register(GlobTool(

--- a/ragnarbot/agent/subagent.py
+++ b/ragnarbot/agent/subagent.py
@@ -16,7 +16,7 @@ from ragnarbot.agent.tools.deliver_result import DeliverResultTool
 from ragnarbot.agent.tools.registry import ToolRegistry
 from ragnarbot.bus.events import InboundMessage
 from ragnarbot.bus.queue import MessageBus
-from ragnarbot.config.schema import ExecToolConfig
+from ragnarbot.config.schema import ExecToolConfig, SearchToolConfig
 from ragnarbot.providers.base import LLMProvider
 
 BUILTIN_DIR = Path(__file__).parent.parent / "builtin"
@@ -24,6 +24,7 @@ BUILTIN_DIR = Path(__file__).parent.parent / "builtin"
 # Tools that are safe for sub-agents
 SAFE_TOOL_NAMES = {
     "file_read", "file_write", "file_edit", "list_dir",
+    "grep", "glob",
     "exec", "web_search", "web_fetch", "browser",
     "exec_bg", "poll", "output", "kill", "dismiss",
 }
@@ -74,6 +75,7 @@ class SubagentManager:
         brave_api_key: str | None = None,
         search_engine: str = "brave",
         exec_config: ExecToolConfig | None = None,
+        search_config: SearchToolConfig | None = None,
         chat_fn=None,
         on_fallback_batch=None,
         browser_manager=None,
@@ -87,6 +89,7 @@ class SubagentManager:
         self.brave_api_key = brave_api_key
         self.search_engine = search_engine
         self.exec_config = exec_config or ExecToolConfig()
+        self.search_config = search_config or SearchToolConfig()
         self.browser_manager = browser_manager
         self.context_builder = context_builder
         self._tasks: dict[str, AgentTask] = {}
@@ -548,6 +551,7 @@ class SubagentManager:
             ReadFileTool,
             WriteFileTool,
         )
+        from ragnarbot.agent.tools.search import GlobTool, GrepTool
         from ragnarbot.agent.tools.shell import ExecTool
         from ragnarbot.agent.tools.web import WebFetchTool, WebSearchTool
 
@@ -583,6 +587,23 @@ class SubagentManager:
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.exec_config.restrict_to_workspace,
                 safety_guard=self.exec_config.safety_guard,
+            ))
+
+        # Search
+        if "grep" in allowed:
+            reg.register(GrepTool(
+                workspace=self.workspace,
+                backend=self.search_config.backend,
+                max_matches=self.search_config.max_matches,
+                max_output_chars=self.search_config.max_output_chars,
+                timeout=self.search_config.timeout,
+            ))
+        if "glob" in allowed:
+            reg.register(GlobTool(
+                workspace=self.workspace,
+                max_results=self.search_config.max_results,
+                max_output_chars=self.search_config.max_output_chars,
+                timeout=self.search_config.timeout,
             ))
 
         # Web

--- a/ragnarbot/agent/tools/filesystem.py
+++ b/ragnarbot/agent/tools/filesystem.py
@@ -1,12 +1,16 @@
 """File system tools: read, write, edit."""
 
 import base64
+import difflib
 import mimetypes
+import re
 from pathlib import Path
 from typing import Any
 
 from ragnarbot.agent.pathing import resolve_path_in_workspace
 from ragnarbot.agent.tools.base import Tool
+
+EDIT_DIFF_MAX_CHARS = 4_000  # only attach a unified diff to edit results below this size
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5 MB (Anthropic API limit for base64 images)
@@ -258,7 +262,14 @@ class EditFileTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Edit a file by replacing old_text with new_text. The old_text must exist exactly in the file."
+        return (
+            "Replace a text block in an existing file. By default `old_text` must match exactly "
+            "once — include enough surrounding context to be unique. If an exact match is not "
+            "found, a whitespace/indentation-tolerant match is tried automatically and applied "
+            "only when it resolves to a single location (otherwise it errors and asks for more "
+            "context — it never edits the wrong spot). Pass `replace_all=true` to replace every "
+            "occurrence. Always file_read the file first."
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -271,40 +282,133 @@ class EditFileTool(Tool):
                 },
                 "old_text": {
                     "type": "string",
-                    "description": "The exact text to find and replace"
+                    "description": (
+                        "The text to find and replace. Include enough surrounding context to "
+                        "match exactly one location. If no exact match is found, a "
+                        "whitespace-tolerant match is attempted."
+                    )
                 },
                 "new_text": {
                     "type": "string",
-                    "description": "The text to replace with"
+                    "description": "The replacement text, inserted verbatim (include the indentation you want)."
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": (
+                        "Replace every exact occurrence instead of requiring a unique match. "
+                        "Default false. When false and old_text occurs more than once, the edit "
+                        "fails with a count so you can add context."
+                    )
                 }
             },
             "required": ["path", "old_text", "new_text"]
         }
 
-    async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str:
+    async def execute(
+        self, path: str, old_text: str, new_text: str,
+        replace_all: bool = False, **kwargs: Any,
+    ) -> str:
         try:
             file_path = _resolve_path(path, self._workspace)
             if not file_path.exists():
                 return f"Error: File not found: {path}"
 
-            content = file_path.read_text(encoding="utf-8")
+            if old_text == new_text:
+                return "Error: old_text and new_text are identical; nothing to change."
 
-            if old_text not in content:
-                return "Error: old_text not found in file. Make sure it matches exactly."
+            try:
+                # newline="" disables newline translation so CRLF/LF is preserved byte-for-byte.
+                with file_path.open("r", encoding="utf-8", newline="") as fh:
+                    content = fh.read()
+            except UnicodeDecodeError:
+                return f"Error: {path} is not valid UTF-8 text (looks binary); cannot edit."
 
-            # Count occurrences
+            # Phase 1: exact substring match.
             count = content.count(old_text)
-            if count > 1:
-                return f"Warning: old_text appears {count} times. Please provide more context to make it unique."
+            if count == 1:
+                new_content = content.replace(old_text, new_text, 1)
+                mode, n = "exact", 1
+            elif count > 1 and replace_all:
+                new_content = content.replace(old_text, new_text)
+                mode, n = "exact", count
+            elif count > 1:
+                return (
+                    f"Error: old_text matches {count} locations. Pass replace_all=true to replace "
+                    f"all, or add surrounding context to target exactly one."
+                )
+            else:
+                # Phase 2: whitespace/indentation-tolerant fallback (single span only).
+                new_content, err = self._whitespace_tolerant_edit(content, old_text, new_text)
+                if err:
+                    return err
+                mode, n = "whitespace-tolerant", 1
 
-            new_content = content.replace(old_text, new_text, 1)
-            file_path.write_text(new_content, encoding="utf-8")
-
-            return f"Successfully edited {path}"
+            with file_path.open("w", encoding="utf-8", newline="") as fh:
+                fh.write(new_content)
+            return self._success(path, content, new_content, mode, n)
         except PermissionError:
             return f"Error: Permission denied: {path}"
         except Exception as e:
             return f"Error editing file: {str(e)}"
+
+    @staticmethod
+    def _norm(s: str) -> str:
+        """Match key: indentation- and trailing-whitespace-insensitive."""
+        return re.sub(r"[ \t]+", " ", s.strip())
+
+    def _whitespace_tolerant_edit(
+        self, content: str, old_text: str, new_text: str,
+    ) -> tuple[str, str | None]:
+        """Return (new_content, None) on a single normalized match, else ('', error)."""
+        src_keep = content.splitlines(keepends=True)
+        src_plain = [ln.rstrip("\r\n") for ln in src_keep]
+
+        pat = old_text.replace("\r\n", "\n").replace("\r", "\n")
+        pat_trailing_nl = pat.endswith("\n")
+        pat_lines = pat[:-1].split("\n") if pat_trailing_nl else pat.split("\n")
+
+        pat_keys = [self._norm(x) for x in pat_lines]
+        if all(k == "" for k in pat_keys):
+            return "", "Error: old_text is only whitespace; provide real content to match."
+
+        src_keys = [self._norm(x) for x in src_plain]
+        length = len(pat_keys)
+        starts = [
+            i for i in range(0, len(src_keys) - length + 1)
+            if src_keys[i:i + length] == pat_keys
+        ]
+        if not starts:
+            return "", (
+                "Error: old_text not found, even with whitespace-tolerant matching. "
+                "file_read the file and copy the exact text."
+            )
+        if len(starts) > 1:
+            return "", (
+                f"Error: old_text matches {len(starts)} locations after whitespace-tolerant "
+                f"matching. Add more surrounding context so it targets exactly one."
+            )
+
+        i = starts[0]
+        last = i + length - 1
+        char_start = sum(len(src_keep[j]) for j in range(i))
+        text_end = char_start + sum(len(src_keep[j]) for j in range(i, last)) + len(src_plain[last])
+        term = src_keep[last][len(src_plain[last]):]  # "", "\n", or "\r\n"
+        char_end = text_end + (len(term) if pat_trailing_nl else 0)
+        new_content = content[:char_start] + new_text + content[char_end:]
+        return new_content, None
+
+    @staticmethod
+    def _success(path: str, old: str, new: str, mode: str, n: int) -> str:
+        header = f"Successfully edited {path} ({n} replacement(s), {mode} match)."
+        diff = "".join(
+            difflib.unified_diff(
+                old.splitlines(keepends=True), new.splitlines(keepends=True),
+                fromfile=path, tofile=path, n=2,
+            )
+        )
+        if diff and len(diff) <= EDIT_DIFF_MAX_CHARS:
+            return f"{header}\n{diff}"
+        return header
 
 
 class ListDirTool(Tool):

--- a/ragnarbot/agent/tools/filesystem.py
+++ b/ragnarbot/agent/tools/filesystem.py
@@ -11,6 +11,12 @@ from ragnarbot.agent.tools.base import Tool
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5 MB (Anthropic API limit for base64 images)
 
+# file_read windowing/caps
+MAX_READ_CHARS = 50_000  # hard ceiling on returned text (matches web_fetch default)
+DEFAULT_LINE_LIMIT = 2_000  # default number of lines when `limit` is omitted
+MAX_LINE_CHARS = 2_000  # truncate any single returned line (minified files)
+HARD_FILE_BYTES = 25 * 1024 * 1024  # refuse to load files larger than this
+
 
 def _resolve_path(path: str, workspace: Path | None = None) -> Path:
     """Resolve a user path, anchoring relative paths to the active workspace."""
@@ -31,8 +37,12 @@ class ReadFileTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Read the contents of a file at the given path. "
-            "For image files (jpg, png, gif, webp) the content "
+            "Read the contents of a file at the given path. Returns up to "
+            f"{DEFAULT_LINE_LIMIT} lines / {MAX_READ_CHARS} characters per call. "
+            "Page through large files with `offset` (1-based start line) and `limit`; "
+            "when output is capped, a footer tells you the next offset to use. "
+            "Pass `line_numbers=true` to prefix line numbers (do NOT copy those prefixes "
+            "into edit_file's old_text). For image files (jpg, png, gif, webp) the content "
             "is returned as a visual image so you can see and describe it."
         )
 
@@ -44,12 +54,40 @@ class ReadFileTool(Tool):
                 "path": {
                     "type": "string",
                     "description": "The file path to read"
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "1-based line number to start reading from. Defaults to 1."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        f"Maximum number of lines to read from offset. Defaults to "
+                        f"{DEFAULT_LINE_LIMIT}. Output is also hard-capped at "
+                        f"{MAX_READ_CHARS} characters."
+                    )
+                },
+                "line_numbers": {
+                    "type": "boolean",
+                    "description": (
+                        "Prefix each line with its absolute line number. Default false. "
+                        "Do not copy the number prefixes into edit_file's old_text."
+                    )
                 }
             },
             "required": ["path"]
         }
 
-    async def execute(self, path: str, **kwargs: Any) -> str | list[dict[str, Any]]:
+    async def execute(
+        self,
+        path: str,
+        offset: int | None = None,
+        limit: int | None = None,
+        line_numbers: bool = False,
+        **kwargs: Any,
+    ) -> str | list[dict[str, Any]]:
         try:
             file_path = _resolve_path(path, self._workspace)
             if not file_path.exists():
@@ -57,7 +95,7 @@ class ReadFileTool(Tool):
             if not file_path.is_file():
                 return f"Error: Not a file: {path}"
 
-            # Image files → multimodal visual content
+            # Image files → multimodal visual content (offset/limit ignored)
             if file_path.suffix.lower() in IMAGE_EXTENSIONS:
                 if self._model:
                     from ragnarbot.config.providers import model_supports_vision
@@ -68,12 +106,72 @@ class ReadFileTool(Tool):
                         )
                 return self._read_image(file_path, path)
 
-            content = file_path.read_text(encoding="utf-8")
-            return content
+            if file_path.stat().st_size > HARD_FILE_BYTES:
+                mb = HARD_FILE_BYTES / (1024 * 1024)
+                return (
+                    f"Error: File exceeds {mb:.0f} MB read limit: {path}. "
+                    f"Use exec with a tool like sed/head to read part of it."
+                )
+
+            try:
+                content = file_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                return (
+                    f"Error: {path} is not valid UTF-8 text (looks binary). "
+                    f"Use exec with a tool like xxd/hexdump, or read an image file."
+                )
+
+            if content == "":
+                return "(file is empty)"
+
+            return self._window(content, offset, limit, line_numbers)
         except PermissionError:
             return f"Error: Permission denied: {path}"
         except Exception as e:
             return f"Error reading file: {str(e)}"
+
+    @staticmethod
+    def _window(
+        content: str, offset: int | None, limit: int | None, line_numbers: bool,
+    ) -> str:
+        """Return a line window of `content`, capped by line count and char budget."""
+        lines = content.split("\n")  # split/join on \n → exact round-trip
+        total = len(lines)
+        start = offset or 1
+        if start > total:
+            return f"Error: offset {start} is past end of file ({total} lines)."
+        eff_limit = limit or DEFAULT_LINE_LIMIT
+        end = min(start + eff_limit - 1, total)  # inclusive, 1-based
+
+        emitted: list[str] = []
+        chars = 0
+        char_capped = False
+        last = start - 1
+        for n in range(start, end + 1):
+            text = lines[n - 1]
+            if len(text) > MAX_LINE_CHARS:
+                text = text[:MAX_LINE_CHARS] + " …(truncated)"
+            rendered = f"{n:>6}\t{text}" if line_numbers else text
+            # Always emit at least one line so offset can advance.
+            if emitted and chars + len(rendered) + 1 > MAX_READ_CHARS:
+                char_capped = True
+                break
+            emitted.append(rendered)
+            chars += len(rendered) + 1
+            last = n
+
+        body = "\n".join(emitted)
+        if start == 1 and last == total and not char_capped:
+            return body  # whole file shown → exact, no footer (backward compatible)
+        if char_capped:
+            return (
+                f"{body}\n\n[truncated at {MAX_READ_CHARS}-char cap — showing lines "
+                f"{start}-{last} of {total}; continue with offset={last + 1}]"
+            )
+        return (
+            f"{body}\n\n[showing lines {start}-{last} of {total}; "
+            f"read more with offset={last + 1}]"
+        )
 
     @staticmethod
     def _read_image(file_path: Path, display_path: str) -> str | list[dict[str, Any]]:

--- a/ragnarbot/agent/tools/ripgrep.py
+++ b/ragnarbot/agent/tools/ripgrep.py
@@ -1,0 +1,137 @@
+"""Lazy provisioning of the official ripgrep binary.
+
+When ripgrep is not on PATH, the grep tool can download the official
+prebuilt binary from the BurntSushi/ripgrep releases into the profile's
+data root on first use (mirroring how the browser tool installs Chromium).
+Resolution is best-effort: any failure returns None so grep falls back to
+its pure-Python backend instead of erroring.
+"""
+
+import asyncio
+import os
+import platform
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+import httpx
+from loguru import logger
+
+RIPGREP_VERSION = "14.1.1"
+
+# (platform.system(), platform.machine()) -> release asset filename template
+_ASSETS = {
+    ("Darwin", "arm64"): "ripgrep-{v}-aarch64-apple-darwin.tar.gz",
+    ("Darwin", "x86_64"): "ripgrep-{v}-x86_64-apple-darwin.tar.gz",
+    ("Linux", "x86_64"): "ripgrep-{v}-x86_64-unknown-linux-musl.tar.gz",
+    ("Linux", "aarch64"): "ripgrep-{v}-aarch64-unknown-linux-gnu.tar.gz",
+    ("Windows", "AMD64"): "ripgrep-{v}-x86_64-pc-windows-msvc.zip",
+}
+_DOWNLOAD_URL = "https://github.com/BurntSushi/ripgrep/releases/download/{v}/{asset}"
+
+_download_lock = asyncio.Lock()
+
+
+def asset_name() -> str | None:
+    """Return the release asset filename for the current platform, or None."""
+    template = _ASSETS.get((platform.system(), platform.machine()))
+    return template.format(v=RIPGREP_VERSION) if template else None
+
+
+def managed_rg_path(data_root: Path) -> Path:
+    """Path where the downloaded rg binary is cached, versioned per release."""
+    exe = "rg.exe" if platform.system() == "Windows" else "rg"
+    return Path(data_root) / "tools" / "ripgrep" / RIPGREP_VERSION / exe
+
+
+async def ensure_ripgrep(data_root: Path | None, *, allow_download: bool = True) -> str | None:
+    """Return a path to a working rg binary, or None if unavailable.
+
+    Resolution order: system rg on PATH → previously downloaded managed
+    binary → fresh download (when allowed). Never raises.
+    """
+    sys_rg = shutil.which("rg")
+    if sys_rg:
+        return sys_rg
+    if data_root is None:
+        return None
+
+    dest = managed_rg_path(data_root)
+    if dest.exists() and os.access(dest, os.X_OK):
+        return str(dest)
+    if not allow_download:
+        return None
+
+    asset = asset_name()
+    if not asset:
+        logger.debug("ripgrep auto-install: unsupported platform {}", platform.platform())
+        return None
+
+    async with _download_lock:
+        # Re-check after acquiring the lock (another task may have finished).
+        if dest.exists() and os.access(dest, os.X_OK):
+            return str(dest)
+        try:
+            logger.info("Installing ripgrep {} (first-time setup)...", RIPGREP_VERSION)
+            await _download_and_extract(asset, dest)
+            logger.info("ripgrep installed at {}", dest)
+            return str(dest)
+        except Exception as exc:
+            logger.warning(
+                "ripgrep auto-install failed ({}); using the Python search fallback", exc
+            )
+            return None
+
+
+async def _download_and_extract(asset: str, dest: Path) -> None:
+    url = _DOWNLOAD_URL.format(v=RIPGREP_VERSION, asset=asset)
+    is_zip = asset.endswith(".zip")
+
+    async with httpx.AsyncClient(follow_redirects=True, timeout=120.0) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.content
+
+    def _extract() -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # Stage in a temp dir on the SAME filesystem so os.replace is atomic.
+        with tempfile.TemporaryDirectory(dir=str(dest.parent)) as td:
+            archive = Path(td) / ("rg.zip" if is_zip else "rg.tar.gz")
+            archive.write_bytes(data)
+            staged = Path(td) / dest.name
+            _extract_binary(archive, staged, is_zip)
+            staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            os.replace(staged, dest)
+
+    await asyncio.to_thread(_extract)
+
+
+def _extract_binary(archive: Path, dest_bin: Path, is_zip: bool) -> None:
+    target = "rg.exe" if is_zip else "rg"
+    if is_zip:
+        with zipfile.ZipFile(archive) as zf:
+            member = _find_member(zf.namelist(), target)
+            if not member:
+                raise RuntimeError(f"{target} not found in ripgrep archive")
+            with zf.open(member) as src, dest_bin.open("wb") as out:
+                shutil.copyfileobj(src, out)
+    else:
+        with tarfile.open(archive, "r:gz") as tf:
+            member = _find_member(tf.getnames(), target)
+            if not member:
+                raise RuntimeError(f"{target} not found in ripgrep archive")
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                raise RuntimeError("could not read rg from ripgrep archive")
+            with extracted as src, dest_bin.open("wb") as out:
+                shutil.copyfileobj(src, out)
+
+
+def _find_member(names: list[str], target: str) -> str | None:
+    for n in names:
+        if n.rsplit("/", 1)[-1] == target:
+            return n
+    return None

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -52,6 +52,38 @@ def _matches_glob(rel: str, name: str, glob: str | None) -> bool:
     return fnmatch.fnmatch(name, glob)
 
 
+def _smart_case_insensitive(pattern: str, override: bool | None) -> bool:
+    """Smart-case: insensitive unless the pattern has an uppercase letter.
+
+    An explicit override (True/False) wins; None enables smart-case.
+    """
+    if override is not None:
+        return override
+    return not any(c.isupper() for c in pattern)
+
+
+def _ci_glob_pattern(pattern: str) -> str:
+    """Expand cased letters to [aA]-style classes so pathlib glob is case-insensitive.
+
+    Portable across Python 3.11+ (no `case_sensitive` kwarg, which is 3.12+), and
+    preserves pathlib's path/`**` semantics since matching still runs through glob().
+    """
+    out: list[str] = []
+    in_class = False
+    for ch in pattern:
+        if ch == "[":
+            in_class = True
+            out.append(ch)
+        elif ch == "]":
+            in_class = False
+            out.append(ch)
+        elif ch.isalpha() and not in_class and ch.lower() != ch.upper():
+            out.append(f"[{ch.lower()}{ch.upper()}]")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 class GrepTool(Tool):
     """Search file contents for a regular expression."""
 
@@ -84,8 +116,9 @@ class GrepTool(Tool):
             "shell grep/rg — it handles regex escaping, returns clean path:line:text output, and "
             "is never blocked by the shell safety guard. Searches the workspace by default, but "
             "pass an absolute `path` (e.g. /Users/you/projects/foo) to search anywhere on the "
-            "machine — no need to drop to `exec find`. Filter files with `glob` (e.g. '*.py'), "
-            "pick verbosity with `output_mode`, and add `context_lines` for surrounding context."
+            "machine — no need to drop to `exec find`. Matching is smart-case (a lowercase "
+            "pattern ignores case; add an uppercase letter to match case exactly). Filter files "
+            "with `glob` (e.g. '*.py'), pick verbosity with `output_mode`, add `context_lines`."
         )
 
     @property
@@ -111,7 +144,11 @@ class GrepTool(Tool):
                 },
                 "case_insensitive": {
                     "type": "boolean",
-                    "description": "Case-insensitive match. Default false.",
+                    "description": (
+                        "Force case sensitivity. Omit for smart-case (insensitive unless the "
+                        "pattern contains an uppercase letter). Set true to always ignore case, "
+                        "false to always match case."
+                    ),
                 },
                 "context_lines": {
                     "type": "integer",
@@ -141,13 +178,14 @@ class GrepTool(Tool):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
-        case_insensitive: bool = False,
+        case_insensitive: bool | None = None,
         context_lines: int = 0,
         output_mode: str = "content",
         max_matches: int | None = None,
         **kwargs: Any,
     ) -> str:
         cap = max_matches or self.max_matches
+        insensitive = _smart_case_insensitive(pattern, case_insensitive)
         root = resolve_path_in_workspace(path or ".", self._workspace)
         if not root.exists():
             return f"Error: path not found: {path or '.'}"
@@ -166,7 +204,7 @@ class GrepTool(Tool):
         try:
             if use_rg:
                 lines, truncated, err = await self._run_rg(
-                    use_rg, pattern, root, glob, case_insensitive,
+                    use_rg, pattern, root, glob, insensitive,
                     context_lines, output_mode, cap,
                 )
                 if err:
@@ -174,7 +212,7 @@ class GrepTool(Tool):
             else:
                 lines, truncated = await asyncio.wait_for(
                     asyncio.to_thread(
-                        self._run_python, pattern, root, glob, case_insensitive,
+                        self._run_python, pattern, root, glob, insensitive,
                         context_lines, output_mode, cap,
                     ),
                     timeout=self.timeout,
@@ -398,9 +436,10 @@ class GlobTool(Tool):
             "Find files by name pattern (e.g. '**/*.md', 'src/**/*.py'), sorted by modification "
             "time (most recent first). Cleaner and faster than `exec` with `find`. Searches the "
             "workspace by default, but pass an absolute `path` (e.g. /Users/you/projects/foo) to "
-            "search anywhere on the machine — no need to drop to `exec find`. Use "
-            "`modified_within` (e.g. '24h') to find recently changed files. Returns relative "
-            "paths, one per line."
+            "search anywhere on the machine — no need to drop to `exec find`. Matching is "
+            "smart-case (a lowercase pattern ignores case, so '*soul*' finds SOUL.md; add an "
+            "uppercase letter to match case exactly). Use `modified_within` (e.g. '24h') for "
+            "recently changed files. Returns relative paths, one per line."
         )
 
     @property
@@ -434,6 +473,14 @@ class GlobTool(Tool):
                     "type": "string",
                     "description": "Only files modified within this window, e.g. '30m', '24h', '7d', or seconds.",
                 },
+                "case_insensitive": {
+                    "type": "boolean",
+                    "description": (
+                        "Force case sensitivity. Omit for smart-case (insensitive unless the "
+                        "pattern contains an uppercase letter). Set true to always ignore case, "
+                        "false to always match case."
+                    ),
+                },
             },
             "required": ["pattern"],
         }
@@ -445,6 +492,7 @@ class GlobTool(Tool):
         sort: str = "mtime",
         limit: int | None = None,
         modified_within: str | None = None,
+        case_insensitive: bool | None = None,
         **kwargs: Any,
     ) -> str:
         cap = limit or self.max_results
@@ -461,9 +509,15 @@ class GlobTool(Tool):
                 return f"Error: invalid modified_within '{modified_within}'. Use e.g. '30m', '24h', '7d'."
             cutoff = time.time() - secs
 
+        # Smart-case: a lowercase pattern matches case-insensitively. We expand cased
+        # letters to [aA] classes (portable on 3.11; preserves pathlib '**' semantics).
+        glob_pattern = pattern
+        if _smart_case_insensitive(pattern, case_insensitive):
+            glob_pattern = _ci_glob_pattern(pattern)
+
         try:
             hits = await asyncio.wait_for(
-                asyncio.to_thread(self._collect, base, pattern, cutoff),
+                asyncio.to_thread(self._collect, base, glob_pattern, cutoff),
                 timeout=self.timeout,
             )
         except asyncio.TimeoutError:

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -63,6 +63,7 @@ class GrepTool(Tool):
         max_output_chars: int = 20000,
         timeout: int = 30,
         auto_install: bool = True,
+        data_root: Path | None = None,
     ):
         self._workspace = workspace
         self.backend = backend
@@ -70,6 +71,7 @@ class GrepTool(Tool):
         self.max_output_chars = max_output_chars
         self.timeout = timeout
         self.auto_install = auto_install
+        self._data_root_override = data_root
 
     @property
     def name(self) -> str:
@@ -182,9 +184,10 @@ class GrepTool(Tool):
             return "No matches found."
         return self._format(lines, truncated, output_mode, cap)
 
-    @staticmethod
-    def _data_root() -> Path | None:
+    def _data_root(self) -> Path | None:
         """Profile data root for caching an auto-installed rg binary."""
+        if self._data_root_override is not None:
+            return self._data_root_override
         try:
             from ragnarbot.instance import get_instance
             return get_instance().data_root
@@ -211,12 +214,15 @@ class GrepTool(Tool):
             return root.parent, root.name
         return root, "."
 
-    async def _run_rg(
-        self, rg, pattern, root, glob, case_insensitive,
-        context_lines, output_mode, cap,
-    ) -> tuple[list[str], bool, str | None]:
-        cwd, target = self._search_base(root)
-        args = [rg, "--line-number", "--no-heading", "--color", "never", "--sort", "path"]
+    @staticmethod
+    def _rg_argv(rg, pattern, target, glob, case_insensitive, context_lines, output_mode):
+        # --no-ignore --hidden: do NOT honor .gitignore/hidden rules, so the rg
+        # backend searches the same files as the Python fallback. We still prune the
+        # known junk dirs explicitly so results aren't flooded by .git/node_modules/etc.
+        args = [rg, "--line-number", "--no-heading", "--color", "never", "--sort", "path",
+                "--no-ignore", "--hidden"]
+        for d in sorted(PY_SKIP_DIRS):
+            args += ["-g", f"!{d}"]
         if case_insensitive:
             args.append("-i")
         if output_mode == "files_with_matches":
@@ -228,6 +234,14 @@ class GrepTool(Tool):
         if glob:
             args += ["-g", glob]
         args += ["-e", pattern, "--", target]
+        return args
+
+    async def _run_rg(
+        self, rg, pattern, root, glob, case_insensitive,
+        context_lines, output_mode, cap,
+    ) -> tuple[list[str], bool, str | None]:
+        cwd, target = self._search_base(root)
+        args = self._rg_argv(rg, pattern, target, glob, case_insensitive, context_lines, output_mode)
 
         proc = await asyncio.create_subprocess_exec(
             *args, cwd=str(cwd),

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -81,10 +81,11 @@ class GrepTool(Tool):
     def description(self) -> str:
         return (
             "Search file contents with a regular expression. Prefer this over `exec` with "
-            "shell grep/rg — it handles regex escaping, stays scoped to the workspace, returns "
-            "clean path:line:text output, and is never blocked by the shell safety guard. "
-            "Filter files with `glob` (e.g. '*.py'), pick verbosity with `output_mode`, and "
-            "add `context_lines` for surrounding context."
+            "shell grep/rg — it handles regex escaping, returns clean path:line:text output, and "
+            "is never blocked by the shell safety guard. Searches the workspace by default, but "
+            "pass an absolute `path` (e.g. /Users/you/projects/foo) to search anywhere on the "
+            "machine — no need to drop to `exec find`. Filter files with `glob` (e.g. '*.py'), "
+            "pick verbosity with `output_mode`, and add `context_lines` for surrounding context."
         )
 
     @property
@@ -99,7 +100,10 @@ class GrepTool(Tool):
                 },
                 "path": {
                     "type": "string",
-                    "description": "File or directory to search. Defaults to the workspace root.",
+                    "description": (
+                        "File or directory to search. Defaults to the workspace root. Pass an "
+                        "absolute path to search anywhere on the machine (outside the workspace)."
+                    ),
                 },
                 "glob": {
                     "type": "string",
@@ -181,6 +185,11 @@ class GrepTool(Tool):
             return f"Error: invalid regular expression: {exc}"
 
         if not lines:
+            if not path:
+                return (
+                    "No matches found in the workspace. To search elsewhere on the machine, "
+                    "pass an absolute path."
+                )
             return "No matches found."
         return self._format(lines, truncated, output_mode, cap)
 
@@ -387,9 +396,11 @@ class GlobTool(Tool):
     def description(self) -> str:
         return (
             "Find files by name pattern (e.g. '**/*.md', 'src/**/*.py'), sorted by modification "
-            "time (most recent first). Cleaner and faster than `exec` with `find`, scoped to the "
-            "workspace. Use `modified_within` (e.g. '24h') to find recently changed files. "
-            "Returns workspace-relative paths, one per line."
+            "time (most recent first). Cleaner and faster than `exec` with `find`. Searches the "
+            "workspace by default, but pass an absolute `path` (e.g. /Users/you/projects/foo) to "
+            "search anywhere on the machine — no need to drop to `exec find`. Use "
+            "`modified_within` (e.g. '24h') to find recently changed files. Returns relative "
+            "paths, one per line."
         )
 
     @property
@@ -404,7 +415,10 @@ class GlobTool(Tool):
                 },
                 "path": {
                     "type": "string",
-                    "description": "Base directory to search. Defaults to the workspace root.",
+                    "description": (
+                        "Base directory to search. Defaults to the workspace root. Pass an "
+                        "absolute path to search anywhere on the machine (outside the workspace)."
+                    ),
                 },
                 "sort": {
                     "type": "string",
@@ -459,7 +473,8 @@ class GlobTool(Tool):
 
         if not hits:
             within = f" modified within {modified_within}" if modified_within else ""
-            return f"No files matching '{pattern}'{within} under {path or 'the workspace'}."
+            hint = "" if path else " To search outside the workspace, pass an absolute path."
+            return f"No files matching '{pattern}'{within} under {path or 'the workspace'}.{hint}"
 
         if sort == "name":
             hits.sort(key=lambda h: h[0].lower())

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -1,0 +1,473 @@
+"""Search tools: grep (content search) and glob (filename discovery).
+
+These exist so the agent never has to shell out to `exec` + `grep`/`find` for
+routine navigation. Running through these tools (instead of the shell) avoids
+shell-quoting pitfalls, the exec output cap, and the workspace safety-guard, and
+returns clean, capped, workspace-relative results.
+"""
+
+import asyncio
+import fnmatch
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from ragnarbot.agent.pathing import resolve_path_in_workspace
+from ragnarbot.agent.tools.base import Tool
+
+MAX_LINE_CHARS = 500  # truncate any single rendered line to this many chars
+NULL_PROBE_BYTES = 8192  # bytes sniffed to detect binary files
+PY_SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build",
+}
+
+
+def _parse_duration(text: str) -> int | None:
+    """Parse '30m' / '24h' / '7d' / '90s' / '120' (seconds) into seconds."""
+    m = re.fullmatch(r"\s*(\d+)\s*([smhd]?)\s*", text)
+    if not m:
+        return None
+    n = int(m.group(1))
+    unit = m.group(2) or "s"
+    return n * {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+
+
+def _is_binary(path: Path) -> bool:
+    try:
+        with path.open("rb") as fh:
+            return b"\0" in fh.read(NULL_PROBE_BYTES)
+    except OSError:
+        return True
+
+
+def _matches_glob(rel: str, name: str, glob: str | None) -> bool:
+    if not glob:
+        return True
+    if "/" in glob or "**" in glob:
+        return fnmatch.fnmatch(rel, glob)
+    return fnmatch.fnmatch(name, glob)
+
+
+class GrepTool(Tool):
+    """Search file contents for a regular expression."""
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        backend: str = "auto",
+        max_matches: int = 200,
+        max_output_chars: int = 20000,
+        timeout: int = 30,
+    ):
+        self._workspace = workspace
+        self.backend = backend
+        self.max_matches = max_matches
+        self.max_output_chars = max_output_chars
+        self.timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "grep"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search file contents with a regular expression. Prefer this over `exec` with "
+            "shell grep/rg — it handles regex escaping, stays scoped to the workspace, returns "
+            "clean path:line:text output, and is never blocked by the shell safety guard. "
+            "Filter files with `glob` (e.g. '*.py'), pick verbosity with `output_mode`, and "
+            "add `context_lines` for surrounding context."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Regular expression to search for (e.g. 'def \\w+_handler').",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "File or directory to search. Defaults to the workspace root.",
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "Filter files by name, e.g. '*.md' or '*.py'.",
+                },
+                "case_insensitive": {
+                    "type": "boolean",
+                    "description": "Case-insensitive match. Default false.",
+                },
+                "context_lines": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 20,
+                    "description": "Lines of context before and after each match. Default 0.",
+                },
+                "output_mode": {
+                    "type": "string",
+                    "enum": ["files_with_matches", "content", "count"],
+                    "description": (
+                        "content = path:line:text (default); files_with_matches = matching file "
+                        "paths; count = path:count per file."
+                    ),
+                },
+                "max_matches": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Cap on matches (content) or files (other modes).",
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    async def execute(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        case_insensitive: bool = False,
+        context_lines: int = 0,
+        output_mode: str = "content",
+        max_matches: int | None = None,
+        **kwargs: Any,
+    ) -> str:
+        cap = max_matches or self.max_matches
+        root = resolve_path_in_workspace(path or ".", self._workspace)
+        if not root.exists():
+            return f"Error: path not found: {path or '.'}"
+
+        rg = shutil.which("rg")
+        if self.backend == "ripgrep" and not rg:
+            return "Error: backend is set to 'ripgrep' but ripgrep (rg) is not installed."
+        use_rg = rg if (self.backend == "ripgrep" or (self.backend == "auto" and rg)) else None
+
+        try:
+            if use_rg:
+                lines, truncated, err = await self._run_rg(
+                    use_rg, pattern, root, glob, case_insensitive,
+                    context_lines, output_mode, cap,
+                )
+                if err:
+                    return err
+            else:
+                lines, truncated = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        self._run_python, pattern, root, glob, case_insensitive,
+                        context_lines, output_mode, cap,
+                    ),
+                    timeout=self.timeout,
+                )
+        except asyncio.TimeoutError:
+            return f"Error: grep timed out after {self.timeout}s. Narrow the path or pattern."
+        except re.error as exc:
+            return f"Error: invalid regular expression: {exc}"
+
+        if not lines:
+            return "No matches found."
+        return self._format(lines, truncated, output_mode, cap)
+
+    def _format(self, lines: list[str], truncated: bool, output_mode: str, cap: int) -> str:
+        body = "\n".join(lines)
+        notes = []
+        if len(body) > self.max_output_chars:
+            body = body[: self.max_output_chars]
+            notes.append(f"... (output truncated at {self.max_output_chars} chars)")
+        if truncated:
+            unit = "matches" if output_mode == "content" else "files"
+            notes.append(f"... (stopped at {cap} {unit}; refine the search to see more)")
+        if notes:
+            body = f"{body}\n" + "\n".join(notes)
+        return body
+
+    @staticmethod
+    def _search_base(root: Path) -> tuple[Path, str]:
+        """Return (cwd, target) so output paths are relative to the search base."""
+        if root.is_file():
+            return root.parent, root.name
+        return root, "."
+
+    async def _run_rg(
+        self, rg, pattern, root, glob, case_insensitive,
+        context_lines, output_mode, cap,
+    ) -> tuple[list[str], bool, str | None]:
+        cwd, target = self._search_base(root)
+        args = [rg, "--line-number", "--no-heading", "--color", "never", "--sort", "path"]
+        if case_insensitive:
+            args.append("-i")
+        if output_mode == "files_with_matches":
+            args.append("-l")
+        elif output_mode == "count":
+            args.append("-c")
+        elif context_lines:
+            args += ["-C", str(context_lines)]
+        if glob:
+            args += ["-g", glob]
+        args += ["-e", pattern, "--", target]
+
+        proc = await asyncio.create_subprocess_exec(
+            *args, cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        lines: list[str] = []
+        truncated = False
+        try:
+            while True:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=self.timeout)
+                if not raw:
+                    break
+                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                if line.startswith("./"):  # rg prints './path' when searching '.'
+                    line = line[2:]
+                if len(line) > MAX_LINE_CHARS:
+                    line = line[:MAX_LINE_CHARS] + " …(truncated)"
+                lines.append(line)
+                if len(lines) >= cap:
+                    truncated = True
+                    break
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        if truncated:
+            proc.kill()
+        await proc.wait()
+        if not truncated and proc.returncode == 2:
+            stderr = (await proc.stderr.read()).decode("utf-8", errors="replace").strip()
+            first = stderr.splitlines()[0] if stderr else "ripgrep error"
+            return [], False, f"Error: {first}"
+        return lines, truncated, None
+
+    def _run_python(
+        self, pattern, root, glob, case_insensitive,
+        context_lines, output_mode, cap,
+    ) -> tuple[list[str], bool]:
+        regex = re.compile(pattern, re.IGNORECASE if case_insensitive else 0)
+        base = root.parent if root.is_file() else root
+
+        rendered: list[str] = []
+        units = 0
+        truncated = False
+        for fpath in self._iter_files(root, glob):
+            if _is_binary(fpath):
+                continue
+            try:
+                text = fpath.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            rel = self._rel(fpath, base)
+            file_lines = text.split("\n")
+            match_idx = [i for i, ln in enumerate(file_lines) if regex.search(ln)]
+            if not match_idx:
+                continue
+
+            if output_mode == "files_with_matches":
+                rendered.append(rel)
+                units += 1
+            elif output_mode == "count":
+                rendered.append(f"{rel}:{len(match_idx)}")
+                units += 1
+            else:  # content
+                emitted, n = self._render_content(
+                    rel, file_lines, match_idx, context_lines, cap - units
+                )
+                rendered.extend(emitted)
+                units += n
+                if len(match_idx) > n:  # this file alone overflowed the cap
+                    truncated = True
+                    break
+            if units >= cap:
+                truncated = True
+                break
+        return rendered, truncated
+
+    def _iter_files(self, root: Path, glob: str | None):
+        if root.is_file():
+            yield root
+            return
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = sorted(d for d in dirnames if d not in PY_SKIP_DIRS)
+            for fn in sorted(filenames):
+                full = Path(dirpath) / fn
+                rel = self._rel(full, root)
+                if _matches_glob(rel, fn, glob):
+                    yield full
+
+    @staticmethod
+    def _rel(path: Path, base: Path) -> str:
+        try:
+            return str(path.relative_to(base))
+        except ValueError:
+            return str(path)
+
+    @staticmethod
+    def _render_content(
+        rel: str, file_lines: list[str], match_idx: list[int], context_lines: int, remaining: int,
+    ) -> tuple[list[str], int]:
+        if remaining <= 0:
+            return [], 0
+        keep = match_idx[:remaining]
+        matchset = set(keep)
+        show: set[int] = set()
+        for i in keep:
+            for j in range(max(0, i - context_lines), min(len(file_lines), i + context_lines + 1)):
+                show.add(j)
+        out: list[str] = []
+        prev: int | None = None
+        for j in sorted(show):
+            if prev is not None and j != prev + 1:
+                out.append("--")
+            sep = ":" if j in matchset else "-"
+            text = file_lines[j]
+            if len(text) > MAX_LINE_CHARS:
+                text = text[:MAX_LINE_CHARS] + " …(truncated)"
+            out.append(f"{rel}{sep}{j + 1}{sep}{text}")
+            prev = j
+        return out, len(keep)
+
+
+class GlobTool(Tool):
+    """Find files by name pattern, most-recently-modified first."""
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        max_results: int = 200,
+        max_output_chars: int = 20000,
+        timeout: int = 30,
+    ):
+        self._workspace = workspace
+        self.max_results = max_results
+        self.max_output_chars = max_output_chars
+        self.timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "glob"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Find files by name pattern (e.g. '**/*.md', 'src/**/*.py'), sorted by modification "
+            "time (most recent first). Cleaner and faster than `exec` with `find`, scoped to the "
+            "workspace. Use `modified_within` (e.g. '24h') to find recently changed files. "
+            "Returns workspace-relative paths, one per line."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Glob pattern, e.g. '**/*.py' (recursive) or 'docs/*.md'.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Base directory to search. Defaults to the workspace root.",
+                },
+                "sort": {
+                    "type": "string",
+                    "enum": ["mtime", "name"],
+                    "description": "'mtime' = most recently modified first (default), 'name' = alphabetical.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Max number of files to return.",
+                },
+                "modified_within": {
+                    "type": "string",
+                    "description": "Only files modified within this window, e.g. '30m', '24h', '7d', or seconds.",
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    async def execute(
+        self,
+        pattern: str,
+        path: str | None = None,
+        sort: str = "mtime",
+        limit: int | None = None,
+        modified_within: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        cap = limit or self.max_results
+        base = resolve_path_in_workspace(path or ".", self._workspace)
+        if not base.exists():
+            return f"Error: path not found: {path or '.'}"
+        if not base.is_dir():
+            return f"Error: path is not a directory: {path or '.'}"
+
+        cutoff: float | None = None
+        if modified_within:
+            secs = _parse_duration(modified_within)
+            if secs is None:
+                return f"Error: invalid modified_within '{modified_within}'. Use e.g. '30m', '24h', '7d'."
+            cutoff = time.time() - secs
+
+        try:
+            hits = await asyncio.wait_for(
+                asyncio.to_thread(self._collect, base, pattern, cutoff),
+                timeout=self.timeout,
+            )
+        except asyncio.TimeoutError:
+            return f"Error: glob timed out after {self.timeout}s. Narrow the pattern or path."
+        except (NotImplementedError, ValueError) as exc:
+            return f"Error: invalid glob pattern '{pattern}': {exc}"
+
+        if not hits:
+            within = f" modified within {modified_within}" if modified_within else ""
+            return f"No files matching '{pattern}'{within} under {path or 'the workspace'}."
+
+        if sort == "name":
+            hits.sort(key=lambda h: h[0].lower())
+        else:
+            hits.sort(key=lambda h: h[1], reverse=True)
+
+        truncated = len(hits) > cap
+        shown = hits[:cap]
+        body = "\n".join(rel for rel, _ in shown)
+        notes = []
+        if len(body) > self.max_output_chars:
+            body = body[: self.max_output_chars]
+            notes.append(f"... (output truncated at {self.max_output_chars} chars)")
+        if truncated:
+            notes.append(
+                f"... showing {cap} of {len(hits)} files "
+                f"({len(hits) - cap} omitted; narrow the pattern or raise limit)"
+            )
+        if notes:
+            body = f"{body}\n" + "\n".join(notes)
+        return body
+
+    @staticmethod
+    def _collect(base: Path, pattern: str, cutoff: float | None) -> list[tuple[str, float]]:
+        hits: list[tuple[str, float]] = []
+        for p in base.glob(pattern):
+            if not p.is_file():
+                continue
+            try:
+                rel = p.relative_to(base)
+            except ValueError:
+                rel = p
+            if any(part in PY_SKIP_DIRS for part in rel.parts):
+                continue
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            if cutoff is not None and st.st_mtime < cutoff:
+                continue
+            hits.append((str(rel), st.st_mtime))
+        return hits

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -10,13 +10,13 @@ import asyncio
 import fnmatch
 import os
 import re
-import shutil
 import time
 from pathlib import Path
 from typing import Any
 
 from ragnarbot.agent.pathing import resolve_path_in_workspace
 from ragnarbot.agent.tools.base import Tool
+from ragnarbot.agent.tools.ripgrep import ensure_ripgrep
 
 MAX_LINE_CHARS = 500  # truncate any single rendered line to this many chars
 NULL_PROBE_BYTES = 8192  # bytes sniffed to detect binary files
@@ -62,12 +62,14 @@ class GrepTool(Tool):
         max_matches: int = 200,
         max_output_chars: int = 20000,
         timeout: int = 30,
+        auto_install: bool = True,
     ):
         self._workspace = workspace
         self.backend = backend
         self.max_matches = max_matches
         self.max_output_chars = max_output_chars
         self.timeout = timeout
+        self.auto_install = auto_install
 
     @property
     def name(self) -> str:
@@ -144,10 +146,16 @@ class GrepTool(Tool):
         if not root.exists():
             return f"Error: path not found: {path or '.'}"
 
-        rg = shutil.which("rg")
-        if self.backend == "ripgrep" and not rg:
-            return "Error: backend is set to 'ripgrep' but ripgrep (rg) is not installed."
-        use_rg = rg if (self.backend == "ripgrep" or (self.backend == "auto" and rg)) else None
+        if self.backend == "python":
+            use_rg = None
+        else:
+            use_rg = await ensure_ripgrep(self._data_root(), allow_download=self.auto_install)
+            if self.backend == "ripgrep" and not use_rg:
+                return (
+                    "Error: ripgrep (rg) is not available and could not be installed "
+                    "automatically. Install it (e.g. 'brew install ripgrep'), or set "
+                    "tools.search.backend to 'auto' or 'python'."
+                )
 
         try:
             if use_rg:
@@ -173,6 +181,15 @@ class GrepTool(Tool):
         if not lines:
             return "No matches found."
         return self._format(lines, truncated, output_mode, cap)
+
+    @staticmethod
+    def _data_root() -> Path | None:
+        """Profile data root for caching an auto-installed rg binary."""
+        try:
+            from ragnarbot.instance import get_instance
+            return get_instance().data_root
+        except Exception:
+            return None
 
     def _format(self, lines: list[str], truncated: bool, output_mode: str, cap: int) -> str:
         body = "\n".join(lines)

--- a/ragnarbot/agent/tools/search.py
+++ b/ragnarbot/agent/tools/search.py
@@ -294,22 +294,8 @@ class GrepTool(Tool):
             *args, cwd=str(cwd),
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
         )
-        lines: list[str] = []
-        truncated = False
         try:
-            while True:
-                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=self.timeout)
-                if not raw:
-                    break
-                line = raw.decode("utf-8", errors="replace").rstrip("\n")
-                if line.startswith("./"):  # rg prints './path' when searching '.'
-                    line = line[2:]
-                if len(line) > MAX_LINE_CHARS:
-                    line = line[:MAX_LINE_CHARS] + " …(truncated)"
-                lines.append(line)
-                if len(lines) >= cap:
-                    truncated = True
-                    break
+            lines, truncated = await self._read_rg_output(proc, cap)
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
@@ -322,6 +308,53 @@ class GrepTool(Tool):
             first = stderr.splitlines()[0] if stderr else "ripgrep error"
             return [], False, f"Error: {first}"
         return lines, truncated, None
+
+    async def _read_rg_output(self, proc, cap: int) -> tuple[list[str], bool]:
+        """Read rg stdout in fixed chunks, capped at `cap` lines.
+
+        Uses read() rather than readline() so a single output line longer than
+        asyncio's 64 KiB StreamReader limit can never raise (it is truncated
+        instead). Over-long lines are emitted truncated and their tail skipped.
+        """
+        max_line_bytes = MAX_LINE_CHARS * 8  # generous byte ceiling per output line
+        lines: list[str] = []
+        buf = bytearray()
+        discarding = False  # dropping the tail of an over-long line until its newline
+        while True:
+            chunk = await asyncio.wait_for(proc.stdout.read(65536), timeout=self.timeout)
+            if not chunk:
+                break
+            buf.extend(chunk)
+            if discarding:
+                nl = buf.find(b"\n")
+                if nl == -1:
+                    buf.clear()
+                    continue
+                del buf[: nl + 1]
+                discarding = False
+            while (nl := buf.find(b"\n")) != -1:
+                self._emit_rg_line(bytes(buf[:nl]), lines)
+                del buf[: nl + 1]
+                if len(lines) >= cap:
+                    return lines, True
+            if len(buf) > max_line_bytes:  # over-long line still has no newline
+                self._emit_rg_line(bytes(buf), lines)
+                buf.clear()
+                discarding = True
+                if len(lines) >= cap:
+                    return lines, True
+        if buf and not discarding:
+            self._emit_rg_line(bytes(buf), lines)
+        return lines, False
+
+    @staticmethod
+    def _emit_rg_line(raw: bytes, lines: list[str]) -> None:
+        line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+        if line.startswith("./"):  # rg prints './path' when searching '.'
+            line = line[2:]
+        if len(line) > MAX_LINE_CHARS:
+            line = line[:MAX_LINE_CHARS] + " …(truncated)"
+        lines.append(line)
 
     def _run_python(
         self, pattern, root, glob, case_insensitive,

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -418,6 +418,34 @@ Own it. State what happened. Fix it. Move on. One sentence of acknowledgment is 
 
 ---
 
+## File & Text Navigation Hierarchy
+
+When you need to find or change something on disk, pick the narrowest tool for the job. Reach for `exec` only when these can't express what you need.
+
+| Goal | Tool | Use when |
+|------|------|----------|
+| Find files by name/path | `glob` | You know the name or extension but not the location (`**/*.py`, `**/*.{{js,ts}}`) |
+| Find content across files | `grep` | You're looking for where a symbol, string, or phrase appears |
+| Read a known file | `file_read` | You have the path and want to see (part of) its contents |
+| List one directory | `list_dir` | You want what's directly inside a single folder |
+| Change an existing file | `edit_file` | You're modifying a file that already exists (read it first) |
+| Create a new file | `write_file` | The file doesn't exist yet |
+
+**Default workflow:**
+
+1. **Locate the file.** Know the name? `glob`. Know only some text inside it? `grep`. Just browsing structure? `list_dir`.
+2. **Read narrowly.** Open it with `file_read`. For large files, don't dump the whole thing — `grep` for the line, then `file_read` with `offset`/`limit` around it. Add `line_numbers=true` when you need to anchor an edit.
+3. **Change surgically.** Use `edit_file` with enough surrounding context that `old_text` matches exactly once. Use `write_file` only for brand-new files.
+4. **Verify.** Re-read the changed region (or `grep` for the new text) to confirm the edit landed.
+
+**When NOT to use `exec` for search:**
+
+- Don't shell out to `grep`/`find`/`ls`/`cat` for routine navigation — `grep`, `glob`, `file_read`, and `list_dir` are faster, scoped to the workspace, and return clean, capped results you can act on directly.
+- A `grep` piped through `exec` (e.g. `grep -r ... | head`) is a smell: use the `grep` tool with a `glob` filter instead.
+- Reserve `exec` for what the dedicated tools genuinely can't do: running builds/tests, git operations, multi-step pipelines, or transforming output with `sed`/`awk`/`jq`.
+
+---
+
 ## Skills
 
 Skills extend your capabilities. They are markdown files with instructions for specific tools or workflows.

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -431,16 +431,18 @@ When you need to find or change something on disk, pick the narrowest tool for t
 | Change an existing file | `edit_file` | You're modifying a file that already exists (read it first) |
 | Create a new file | `write_file` | The file doesn't exist yet |
 
+**Workspace by default, the whole machine when you need it.** `glob`, `grep`, `file_read`, and `list_dir` search the workspace when given a relative path, but they all accept an **absolute path** to go anywhere on the machine — your own engine source under `/Users/.../projects/`, system config, logs, etc. If a search of the workspace comes up empty and the thing you want is clearly outside it (the bot's own code, an app's files), re-run the same tool with an absolute `path` — **do not** fall back to `exec find`/`grep`.
+
 **Default workflow:**
 
-1. **Locate the file.** Know the name? `glob`. Know only some text inside it? `grep`. Just browsing structure? `list_dir`.
+1. **Locate the file.** Know the name? `glob`. Know only some text inside it? `grep`. Just browsing structure? `list_dir`. Outside the workspace? Same tools, with an absolute `path`.
 2. **Read narrowly.** Open it with `file_read`. For large files, don't dump the whole thing — `grep` for the line, then `file_read` with `offset`/`limit` around it. Add `line_numbers=true` when you need to anchor an edit.
 3. **Change surgically.** Use `edit_file` with enough surrounding context that `old_text` matches exactly once. Use `write_file` only for brand-new files.
 4. **Verify.** Re-read the changed region (or `grep` for the new text) to confirm the edit landed.
 
 **When NOT to use `exec` for search:**
 
-- Don't shell out to `grep`/`find`/`ls`/`cat` for routine navigation — `grep`, `glob`, `file_read`, and `list_dir` are faster, scoped to the workspace, and return clean, capped results you can act on directly.
+- Don't shell out to `grep`/`find`/`ls`/`cat` for navigation — `grep`, `glob`, `file_read`, and `list_dir` are faster and return clean, capped results you can act on directly. This holds for paths outside the workspace too: give the tool an absolute `path` instead of reaching for `exec find`.
 - A `grep` piped through `exec` (e.g. `grep -r ... | head`) is a smell: use the `grep` tool with a `glob` filter instead.
 - Reserve `exec` for what the dedicated tools genuinely can't do: running builds/tests, git operations, multi-step pipelines, or transforming output with `sed`/`awk`/`jq`.
 

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -3,7 +3,10 @@
 ## File Tools
 
 ### file_read
-Read a file's contents. Always read a file before editing it — you need to see the current content to construct an accurate edit.
+Read a file's contents. Returns up to 2000 lines / 50000 characters per call. Always read a file before editing it — you need to see the current content to construct an accurate edit.
+- Page through large files with `offset` (1-based start line) and `limit` (max lines). When output is capped, a footer tells you the next `offset` to use.
+- Pass `line_numbers=true` to prefix line numbers (handy for locating an offset or planning an edit) — but never copy the number prefixes into `edit_file`'s `old_text`.
+- For a big file, don't dump the whole thing: `grep` for the line you need, then `file_read` a narrow window around it.
 
 Also works with image files (jpg, png, gif, webp) — the image is returned as visual content you can see and describe. Use this to inspect screenshots, generated images, local photos, or any visual file on disk.
 
@@ -11,7 +14,10 @@ Also works with image files (jpg, png, gif, webp) — the image is returned as v
 Write content to a file (creates parent directories automatically). Use for creating new files. For modifying existing files, prefer `edit_file` instead.
 
 ### edit_file
-Replace a specific text block in an existing file. Provide the exact `old_text` to match — it must appear exactly once. Include enough surrounding context to make the match unique. Always `file_read` the file first.
+Replace a text block in an existing file. By default `old_text` must match exactly once — include enough surrounding context to be unique. Always `file_read` the file first.
+- If an exact match fails, a whitespace/indentation-tolerant match is tried automatically and applied only when it resolves to a single location; otherwise it errors and asks for more context (it never edits the wrong spot).
+- Pass `replace_all=true` to replace every occurrence. If `old_text` matches more than one place and `replace_all` is false, the edit fails with a count instead of silently doing nothing.
+- `new_text` is inserted verbatim — include the exact indentation you want. Returns a small diff of what changed.
 
 ### list_dir
 List directory contents. Use to explore project structure or check what files exist before acting.
@@ -24,6 +30,24 @@ Execute a shell command. Returns stdout, stderr, and exit code.
 - Destructive commands (rm -rf, format, dd, etc.) are blocked by safety guards (can be disabled via `tools.exec.safetyGuard: false` in config).
 - Provide `working_dir` when the command must run in a specific directory.
 - For long-running processes, warn the user about potential timeout.
+
+## Search
+
+Find files and content fast. Prefer these over `exec` with `find`/`grep`/`ls` — they're scoped to the workspace, handle escaping for you, and return clean, capped, workspace-relative output.
+
+### glob
+Find files by name pattern. Returns matching paths, most-recently-modified first. Use when you know roughly what a file is called or its extension but not where it lives.
+- `pattern` — a glob like `**/*.py`, `docs/*.md`, or `**/*.{{js,ts}}`.
+- `path` (optional) — directory to search under (defaults to the workspace root).
+- `modified_within` (optional) — only files changed within a window, e.g. `24h`, `7d`.
+
+### grep
+Search file *contents* for a regular expression. Use to find where a symbol, string, or phrase appears.
+- `pattern` — a regular expression (e.g. `def \w+_handler`).
+- `path` (optional) — file or directory to search under.
+- `glob` (optional) — restrict to files matching a glob (e.g. `*.py`).
+- `output_mode` (optional) — `content` (path:line:text, default), `files_with_matches`, or `count`.
+- `context_lines` (optional) — lines of surrounding context per match.
 
 ## Background Execution
 

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -33,18 +33,18 @@ Execute a shell command. Returns stdout, stderr, and exit code.
 
 ## Search
 
-Find files and content fast. Prefer these over `exec` with `find`/`grep`/`ls` — they're scoped to the workspace, handle escaping for you, and return clean, capped, workspace-relative output.
+Find files and content fast. Prefer these over `exec` with `find`/`grep`/`ls` — they handle escaping for you and return clean, capped output. They search the **workspace by default**, but you can pass an **absolute `path`** to search anywhere on the machine (e.g. the bot's own source, system config) — you don't need `exec find` for that.
 
 ### glob
 Find files by name pattern. Returns matching paths, most-recently-modified first. Use when you know roughly what a file is called or its extension but not where it lives.
 - `pattern` — a glob like `**/*.py`, `docs/*.md`, or `**/*.{{js,ts}}`.
-- `path` (optional) — directory to search under (defaults to the workspace root).
+- `path` (optional) — directory to search under. Defaults to the workspace root; pass an absolute path to search outside it.
 - `modified_within` (optional) — only files changed within a window, e.g. `24h`, `7d`.
 
 ### grep
 Search file *contents* for a regular expression. Use to find where a symbol, string, or phrase appears.
 - `pattern` — a regular expression (e.g. `def \w+_handler`).
-- `path` (optional) — file or directory to search under.
+- `path` (optional) — file or directory to search under. Defaults to the workspace root; pass an absolute path to search outside it.
 - `glob` (optional) — restrict to files matching a glob (e.g. `*.py`).
 - `output_mode` (optional) — `content` (path:line:text, default), `files_with_matches`, or `count`.
 - `context_lines` (optional) — lines of surrounding context per match.

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -33,7 +33,7 @@ Execute a shell command. Returns stdout, stderr, and exit code.
 
 ## Search
 
-Find files and content fast. Prefer these over `exec` with `find`/`grep`/`ls` — they handle escaping for you and return clean, capped output. They search the **workspace by default**, but you can pass an **absolute `path`** to search anywhere on the machine (e.g. the bot's own source, system config) — you don't need `exec find` for that.
+Find files and content fast. Prefer these over `exec` with `find`/`grep`/`ls` — they handle escaping for you and return clean, capped output. They search the **workspace by default**, but you can pass an **absolute `path`** to search anywhere on the machine (e.g. the bot's own source, system config) — you don't need `exec find` for that. Matching is **smart-case**: a lowercase pattern ignores case (so `*soul*` finds `SOUL.md`); add an uppercase letter to match case exactly.
 
 ### glob
 Find files by name pattern. Returns matching paths, most-recently-modified first. Use when you know roughly what a file is called or its extension but not where it lives.

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -334,6 +334,7 @@ def gateway_main(
             brave_api_key=brave_api_key,
             search_engine=search_engine,
             exec_config=config.tools.exec,
+            search_config=config.tools.search,
             cron_service=cron,
             hook_service=hook_service,
             stream_steps=config.agents.defaults.stream_steps,

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -178,6 +178,10 @@ class SearchToolConfig(BaseModel):
         pattern="^(auto|ripgrep|python)$",
         json_schema_extra={"reload": "hot", "label": "Search backend (auto|ripgrep|python)"},
     )
+    auto_install: bool = Field(
+        default=True,
+        json_schema_extra={"reload": "hot", "label": "Auto-download ripgrep when missing"},
+    )
     max_matches: int = Field(
         default=200,
         ge=1,

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -171,6 +171,35 @@ class ExecToolConfig(BaseModel):
     )
 
 
+class SearchToolConfig(BaseModel):
+    """grep / glob search tools configuration."""
+    backend: str = Field(
+        default="auto",
+        pattern="^(auto|ripgrep|python)$",
+        json_schema_extra={"reload": "hot", "label": "Search backend (auto|ripgrep|python)"},
+    )
+    max_matches: int = Field(
+        default=200,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Max grep matches returned"},
+    )
+    max_results: int = Field(
+        default=200,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Max glob results returned"},
+    )
+    max_output_chars: int = Field(
+        default=20000,
+        ge=1000,
+        json_schema_extra={"reload": "hot", "label": "Max search output characters"},
+    )
+    timeout: int = Field(
+        default=30,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Search timeout (seconds)"},
+    )
+
+
 class BrowserConfig(BaseModel):
     """Browser automation tool configuration."""
     idle_timeout: int = Field(
@@ -195,6 +224,7 @@ class ToolsConfig(BaseModel):
     """Tools configuration."""
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
+    search: SearchToolConfig = Field(default_factory=SearchToolConfig)
     browser: BrowserConfig = Field(default_factory=BrowserConfig)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures."""
+
+import pytest
+
+from ragnarbot.agent.tools import ripgrep
+
+
+@pytest.fixture(autouse=True)
+def _block_ripgrep_download(monkeypatch):
+    """Never download ripgrep over the network during tests.
+
+    Provisioning logic is unit-tested with mocks in test_ripgrep_provision.py;
+    everywhere else, a blocked download just degrades to the Python search
+    fallback (ensure_ripgrep swallows the error and returns None), so no test
+    hits the network or writes a binary into the real profile data root.
+    """
+    async def _blocked(asset, dest):
+        raise RuntimeError("ripgrep download disabled during tests")
+
+    monkeypatch.setattr(ripgrep, "_download_and_extract", _blocked)

--- a/tests/test_ripgrep_provision.py
+++ b/tests/test_ripgrep_provision.py
@@ -1,0 +1,107 @@
+"""Tests for lazy ripgrep provisioning (no network)."""
+
+import stat
+
+import pytest
+
+from ragnarbot.agent.tools import ripgrep
+
+
+def test_asset_name_known_platforms(monkeypatch):
+    monkeypatch.setattr(ripgrep.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(ripgrep.platform, "machine", lambda: "arm64")
+    assert ripgrep.asset_name() == f"ripgrep-{ripgrep.RIPGREP_VERSION}-aarch64-apple-darwin.tar.gz"
+
+    monkeypatch.setattr(ripgrep.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ripgrep.platform, "machine", lambda: "x86_64")
+    assert ripgrep.asset_name() == f"ripgrep-{ripgrep.RIPGREP_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+
+
+def test_asset_name_unsupported_platform(monkeypatch):
+    monkeypatch.setattr(ripgrep.platform, "system", lambda: "Plan9")
+    monkeypatch.setattr(ripgrep.platform, "machine", lambda: "pdp11")
+    assert ripgrep.asset_name() is None
+
+
+def test_managed_rg_path_is_versioned(tmp_path):
+    p = ripgrep.managed_rg_path(tmp_path)
+    assert ripgrep.RIPGREP_VERSION in str(p)
+    assert p.name in ("rg", "rg.exe")
+
+
+@pytest.mark.asyncio
+async def test_ensure_returns_system_rg(tmp_path, monkeypatch):
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: "/usr/local/bin/rg")
+    result = await ripgrep.ensure_ripgrep(tmp_path)
+    assert result == "/usr/local/bin/rg"
+
+
+@pytest.mark.asyncio
+async def test_ensure_no_download_when_disallowed(tmp_path, monkeypatch):
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: None)
+    result = await ripgrep.ensure_ripgrep(tmp_path, allow_download=False)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_returns_cached_managed_binary(tmp_path, monkeypatch):
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: None)
+    dest = ripgrep.managed_rg_path(tmp_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("#!/bin/sh\n", encoding="utf-8")
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR)
+    # Should return the cached binary without attempting any download.
+    result = await ripgrep.ensure_ripgrep(tmp_path, allow_download=True)
+    assert result == str(dest)
+
+
+@pytest.mark.asyncio
+async def test_ensure_unsupported_platform_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: None)
+    monkeypatch.setattr(ripgrep.platform, "system", lambda: "Plan9")
+    monkeypatch.setattr(ripgrep.platform, "machine", lambda: "pdp11")
+    # No asset for this platform → returns None without any network call.
+    result = await ripgrep.ensure_ripgrep(tmp_path, allow_download=True)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_none_data_root(monkeypatch):
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: None)
+    assert await ripgrep.ensure_ripgrep(None) is None
+
+
+def test_find_member():
+    names = ["ripgrep-14.1.1-aarch64-apple-darwin/doc/rg.1", "ripgrep-14.1.1-aarch64-apple-darwin/rg"]
+    assert ripgrep._find_member(names, "rg") == "ripgrep-14.1.1-aarch64-apple-darwin/rg"
+    assert ripgrep._find_member(names, "rg.exe") is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_download_failure_returns_none(tmp_path, monkeypatch):
+    """A failed download must degrade to None (Python fallback), not raise."""
+    monkeypatch.setattr(ripgrep.shutil, "which", lambda _: None)
+
+    async def _boom(asset, dest):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(ripgrep, "_download_and_extract", _boom)
+    result = await ripgrep.ensure_ripgrep(tmp_path, allow_download=True)
+    assert result is None
+
+
+def test_extract_binary_from_tar(tmp_path):
+    """Extract rg from a tar.gz the way a real release is laid out."""
+    import io
+    import tarfile
+
+    archive = tmp_path / "rg.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        payload = b"#!/bin/sh\necho ripgrep\n"
+        info = tarfile.TarInfo("ripgrep-14.1.1-x/rg")
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+
+    out = tmp_path / "rg"
+    ripgrep._extract_binary(archive, out, is_zip=False)
+    assert out.read_bytes().startswith(b"#!/bin/sh")

--- a/tests/test_search_config.py
+++ b/tests/test_search_config.py
@@ -1,0 +1,40 @@
+"""Tests for the tools.search config block."""
+
+from ragnarbot.config.loader import convert_keys, convert_to_camel
+from ragnarbot.config.schema import Config, SearchToolConfig
+
+
+def test_search_defaults():
+    cfg = Config()
+    assert cfg.tools.search.backend == "auto"
+    assert cfg.tools.search.max_matches == 200
+    assert cfg.tools.search.max_results == 200
+    assert cfg.tools.search.max_output_chars == 20000
+    assert cfg.tools.search.timeout == 30
+
+
+def test_search_camel_serialization():
+    camel = convert_to_camel(Config().model_dump())
+    search = camel["tools"]["search"]
+    assert "maxMatches" in search
+    assert "maxOutputChars" in search
+    assert "backend" in search
+
+
+def test_search_camel_roundtrip_load():
+    raw = {"tools": {"search": {"backend": "python", "maxMatches": 50, "maxOutputChars": 5000}}}
+    cfg = Config(**convert_keys(raw))
+    assert cfg.tools.search.backend == "python"
+    assert cfg.tools.search.max_matches == 50
+    assert cfg.tools.search.max_output_chars == 5000
+    # untouched fields keep defaults
+    assert cfg.tools.search.max_results == 200
+
+
+def test_search_backend_validation():
+    import pytest
+    from pydantic import ValidationError
+
+    SearchToolConfig(backend="ripgrep")  # valid
+    with pytest.raises(ValidationError):
+        SearchToolConfig(backend="bogus")

--- a/tests/test_search_config.py
+++ b/tests/test_search_config.py
@@ -7,6 +7,7 @@ from ragnarbot.config.schema import Config, SearchToolConfig
 def test_search_defaults():
     cfg = Config()
     assert cfg.tools.search.backend == "auto"
+    assert cfg.tools.search.auto_install is True
     assert cfg.tools.search.max_matches == 200
     assert cfg.tools.search.max_results == 200
     assert cfg.tools.search.max_output_chars == 20000

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -94,7 +94,8 @@ async def test_grep_count_mode(tmp_path):
 async def test_grep_no_match(tmp_path):
     _make_corpus(tmp_path)
     tool = GrepTool(workspace=tmp_path, backend="python")
-    result = await tool.execute(pattern="zzznotpresent")
+    # A scoped (non-workspace) search returns the bare message, no hint.
+    result = await tool.execute(pattern="zzznotpresent", path="sub")
     assert result == "No matches found."
 
 
@@ -314,6 +315,47 @@ async def test_glob_invalid_modified_within(tmp_path):
     tool = GlobTool(workspace=tmp_path)
     result = await tool.execute(pattern="*.md", modified_within="soon")
     assert result.startswith("Error: invalid modified_within")
+
+
+# --------------------------- searching outside the workspace ---------------------------
+
+@pytest.mark.asyncio
+async def test_glob_absolute_path_escapes_workspace(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "found.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=ws)
+    result = await tool.execute(pattern="**/*.md", path=str(outside))
+    assert "found.md" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_absolute_path_escapes_workspace(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "note.txt").write_text("needle here\n", encoding="utf-8")
+    tool = GrepTool(workspace=ws, backend="python")
+    result = await tool.execute(pattern="needle", path=str(outside))
+    assert "note.txt:1:needle here" in result
+
+
+@pytest.mark.asyncio
+async def test_glob_empty_hints_absolute_path(tmp_path):
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*.nonexistent")
+    assert "absolute path" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_empty_hints_absolute_path(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="zzznotpresent")
+    assert "absolute path" in result
 
 
 # --------------------------- registry wiring ---------------------------

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -291,3 +292,25 @@ async def test_glob_invalid_modified_within(tmp_path):
     tool = GlobTool(workspace=tmp_path)
     result = await tool.execute(pattern="*.md", modified_within="soon")
     assert result.startswith("Error: invalid modified_within")
+
+
+# --------------------------- registry wiring ---------------------------
+
+def test_subagent_registry_includes_search(tmp_path):
+    """General-purpose subagents get grep/glob via SAFE_TOOL_NAMES."""
+    from ragnarbot.agent.agents_loader import AgentsLoader
+    from ragnarbot.agent.subagent import SubagentManager
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test/model"
+    loader = AgentsLoader(tmp_path / "ws", builtin_agents_dir=tmp_path / "empty")
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path / "ws",
+        bus=MagicMock(),
+        agents_loader=loader,
+        model="test/model",
+    )
+    reg, _ = mgr._build_agent_tool_registry(None, "cli", "direct")
+    assert "grep" in reg.tool_names
+    assert "glob" in reg.tool_names

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -1,5 +1,6 @@
 """Tests for the grep and glob search tools."""
 
+import asyncio
 import os
 import shutil
 import time
@@ -323,6 +324,37 @@ async def test_glob_invalid_modified_within(tmp_path):
     tool = GlobTool(workspace=tmp_path)
     result = await tool.execute(pattern="*.md", modified_within="soon")
     assert result.startswith("Error: invalid modified_within")
+
+
+# --------------------------- long-line handling (no readline 64KB crash) ---------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("cat") is None, reason="cat not available")
+async def test_rg_reader_handles_giant_line(tmp_path):
+    """A line longer than asyncio's 64KB readline limit must not crash."""
+    big = tmp_path / "big.txt"
+    big.write_text("x" * 200_000 + "\n" + "short\n", encoding="utf-8")
+    proc = await asyncio.create_subprocess_exec(
+        "cat", str(big),
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    tool = GrepTool(workspace=tmp_path)
+    lines, truncated = await tool._read_rg_output(proc, cap=100)
+    await proc.wait()
+    assert len(lines) == 2
+    assert lines[0].endswith("…(truncated)")  # giant line truncated, not crashed
+    assert lines[1] == "short"
+
+
+@pytest.mark.asyncio
+async def test_grep_python_handles_giant_line(tmp_path):
+    (tmp_path / "giant.md").write_text(
+        "x" * 200_000 + " needle " + "y" * 50_000 + "\n", encoding="utf-8"
+    )
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="needle", path="giant.md")
+    assert "giant.md:1:" in result
+    assert "…(truncated)" in result  # matched line truncated, no crash
 
 
 # --------------------------- smart-case matching ---------------------------

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -1,0 +1,293 @@
+"""Tests for the grep and glob search tools."""
+
+import os
+import shutil
+import time
+
+import pytest
+
+from ragnarbot.agent.tools.search import GlobTool, GrepTool
+
+
+def _make_corpus(root):
+    """Build a small workspace corpus and return the root path."""
+    (root / "notes.md").write_text("alpha\nBeta\ngamma\n", encoding="utf-8")
+    (root / "many.md").write_text("alpha\nalpha\nalpha\n", encoding="utf-8")
+    (root / "dash.md").write_text("foo-xbar\n", encoding="utf-8")
+    (root / "longline.md").write_text("x" * 600 + "alpha\n", encoding="utf-8")
+    (root / "bin.dat").write_bytes(b"\x00\x01alpha\x00data")
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "code.py").write_text("def handler():\n    return 1\n# alpha here\n", encoding="utf-8")
+    (sub / "data.txt").write_text("nothing relevant\n", encoding="utf-8")
+    return root
+
+
+# --------------------------- grep ---------------------------
+
+@pytest.mark.asyncio
+async def test_grep_content_mode(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="notes.md")
+    assert result == "notes.md:1:alpha"
+
+
+@pytest.mark.asyncio
+async def test_grep_finds_across_files(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha here")
+    assert "sub/code.py:3:# alpha here" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_case_insensitive(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    sensitive = await tool.execute(pattern="beta", path="notes.md")
+    assert sensitive == "No matches found."
+    insensitive = await tool.execute(pattern="beta", path="notes.md", case_insensitive=True)
+    assert insensitive == "notes.md:2:Beta"
+
+
+@pytest.mark.asyncio
+async def test_grep_glob_filter(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", glob="*.md", output_mode="files_with_matches")
+    assert "notes.md" in result
+    assert "sub/code.py" not in result  # .py excluded by *.md filter
+
+
+@pytest.mark.asyncio
+async def test_grep_context_lines(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="Beta", path="notes.md", context_lines=1)
+    lines = result.splitlines()
+    assert "notes.md-1-alpha" in lines
+    assert "notes.md:2:Beta" in lines
+    assert "notes.md-3-gamma" in lines
+
+
+@pytest.mark.asyncio
+async def test_grep_files_with_matches(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", output_mode="files_with_matches")
+    assert "notes.md" in result
+    assert "sub/code.py" in result
+    assert ":" not in result.split("\n")[0]  # paths only, no line:text
+
+
+@pytest.mark.asyncio
+async def test_grep_count_mode(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="many.md", output_mode="count")
+    assert result == "many.md:3"
+
+
+@pytest.mark.asyncio
+async def test_grep_no_match(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="zzznotpresent")
+    assert result == "No matches found."
+
+
+@pytest.mark.asyncio
+async def test_grep_cap_and_footer(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="many.md", max_matches=2)
+    lines = result.splitlines()
+    assert lines[0] == "many.md:1:alpha"
+    assert lines[1] == "many.md:2:alpha"
+    assert "stopped at 2 matches" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_invalid_regex(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="(")
+    assert result.startswith("Error: invalid regular expression")
+
+
+@pytest.mark.asyncio
+async def test_grep_workspace_anchoring(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="sub")
+    assert "code.py:3:# alpha here" in result
+    assert "sub/code.py" not in result  # paths are relative to the searched dir
+
+
+@pytest.mark.asyncio
+async def test_grep_skips_binary(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", output_mode="files_with_matches")
+    assert "bin.dat" not in result
+
+
+@pytest.mark.asyncio
+async def test_grep_per_line_cap(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="longline.md")
+    assert "…(truncated)" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_pattern_with_leading_dash(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="-x", path="dash.md")
+    assert result == "dash.md:1:foo-xbar"
+
+
+@pytest.mark.asyncio
+async def test_grep_path_not_found(tmp_path):
+    tool = GrepTool(workspace=tmp_path, backend="python")
+    result = await tool.execute(pattern="alpha", path="nope")
+    assert result.startswith("Error: path not found")
+
+
+@pytest.mark.asyncio
+async def test_grep_ripgrep_missing_explicit(tmp_path, monkeypatch):
+    _make_corpus(tmp_path)
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    tool = GrepTool(workspace=tmp_path, backend="ripgrep")
+    result = await tool.execute(pattern="alpha")
+    assert "ripgrep" in result and "not installed" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
+async def test_grep_ripgrep_python_parity(tmp_path):
+    corpus = tmp_path / "clean"
+    corpus.mkdir()
+    (corpus / "a.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+    (corpus / "b.txt").write_text("gamma\nalpha\n", encoding="utf-8")
+    rg_tool = GrepTool(workspace=tmp_path, backend="ripgrep")
+    py_tool = GrepTool(workspace=tmp_path, backend="python")
+    rg = await rg_tool.execute(pattern="alpha", path="clean", output_mode="files_with_matches")
+    py = await py_tool.execute(pattern="alpha", path="clean", output_mode="files_with_matches")
+    assert set(rg.splitlines()) == set(py.splitlines()) == {"a.txt", "b.txt"}
+
+
+# --------------------------- glob ---------------------------
+
+@pytest.mark.asyncio
+async def test_glob_recursive_md(tmp_path):
+    _make_corpus(tmp_path)
+    (tmp_path / "sub" / "deep.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*.md")
+    paths = set(result.splitlines())
+    assert "notes.md" in paths
+    assert "sub/deep.md" in paths
+
+
+@pytest.mark.asyncio
+async def test_glob_sort_mtime(tmp_path):
+    old = tmp_path / "old.md"
+    new = tmp_path / "new.md"
+    old.write_text("o", encoding="utf-8")
+    new.write_text("n", encoding="utf-8")
+    now = time.time()
+    os.utime(old, (now - 1000, now - 1000))
+    os.utime(new, (now, now))
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.md", sort="mtime")
+    lines = result.splitlines()
+    assert lines.index("new.md") < lines.index("old.md")
+
+
+@pytest.mark.asyncio
+async def test_glob_sort_name(tmp_path):
+    (tmp_path / "b.md").write_text("b", encoding="utf-8")
+    (tmp_path / "a.md").write_text("a", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.md", sort="name")
+    assert result.splitlines() == ["a.md", "b.md"]
+
+
+@pytest.mark.asyncio
+async def test_glob_limit_and_footer(tmp_path):
+    for i in range(5):
+        (tmp_path / f"f{i}.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.md", limit=2)
+    body = [ln for ln in result.splitlines() if not ln.startswith("...")]
+    assert len(body) == 2
+    assert "showing 2 of 5 files" in result
+
+
+@pytest.mark.asyncio
+async def test_glob_modified_within(tmp_path):
+    recent = tmp_path / "recent.md"
+    stale = tmp_path / "stale.md"
+    recent.write_text("r", encoding="utf-8")
+    stale.write_text("s", encoding="utf-8")
+    now = time.time()
+    os.utime(stale, (now - 7200, now - 7200))  # 2 hours ago
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.md", modified_within="1h")
+    assert "recent.md" in result
+    assert "stale.md" not in result
+
+
+@pytest.mark.asyncio
+async def test_glob_no_match(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*.zzz")
+    assert result.startswith("No files matching")
+
+
+@pytest.mark.asyncio
+async def test_glob_relative_paths(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*.md")
+    assert str(tmp_path) not in result
+
+
+@pytest.mark.asyncio
+async def test_glob_only_files(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*")
+    assert "sub" not in result.splitlines()  # the directory itself is excluded
+
+
+@pytest.mark.asyncio
+async def test_glob_subdir_scope(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.py", path="sub")
+    assert result.splitlines() == ["code.py"]
+
+
+@pytest.mark.asyncio
+async def test_glob_skips_ignored_dirs(tmp_path):
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    (cache / "junk.md").write_text("x", encoding="utf-8")
+    (tmp_path / "real.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*.md")
+    assert "real.md" in result
+    assert "junk.md" not in result
+
+
+@pytest.mark.asyncio
+async def test_glob_invalid_modified_within(tmp_path):
+    _make_corpus(tmp_path)
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*.md", modified_within="soon")
+    assert result.startswith("Error: invalid modified_within")

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -43,13 +43,21 @@ async def test_grep_finds_across_files(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_grep_case_insensitive(tmp_path):
-    _make_corpus(tmp_path)
+async def test_grep_smart_case(tmp_path):
+    _make_corpus(tmp_path)  # notes.md has "Beta" on line 2
     tool = GrepTool(workspace=tmp_path, backend="python")
-    sensitive = await tool.execute(pattern="beta", path="notes.md")
-    assert sensitive == "No matches found."
-    insensitive = await tool.execute(pattern="beta", path="notes.md", case_insensitive=True)
-    assert insensitive == "notes.md:2:Beta"
+    # lowercase pattern -> smart-case insensitive -> matches "Beta"
+    assert await tool.execute(pattern="beta", path="notes.md") == "notes.md:2:Beta"
+    # uppercase letter in pattern -> case-sensitive -> "BETA" doesn't match "Beta"
+    assert await tool.execute(pattern="BETA", path="notes.md") == "No matches found."
+    # explicit override: force insensitive
+    assert await tool.execute(
+        pattern="BETA", path="notes.md", case_insensitive=True
+    ) == "notes.md:2:Beta"
+    # explicit override: force sensitive
+    assert await tool.execute(
+        pattern="beta", path="notes.md", case_insensitive=False
+    ) == "No matches found."
 
 
 @pytest.mark.asyncio
@@ -315,6 +323,52 @@ async def test_glob_invalid_modified_within(tmp_path):
     tool = GlobTool(workspace=tmp_path)
     result = await tool.execute(pattern="*.md", modified_within="soon")
     assert result.startswith("Error: invalid modified_within")
+
+
+# --------------------------- smart-case matching ---------------------------
+
+def test_ci_glob_pattern_expands_letters():
+    from ragnarbot.agent.tools.search import _ci_glob_pattern
+    assert _ci_glob_pattern("*soul*") == "*[sS][oO][uU][lL]*"
+    assert _ci_glob_pattern("**/*.md") == "**/*.[mM][dD]"  # ** and . preserved
+    # letters inside an existing [...] class are left alone
+    assert _ci_glob_pattern("[abc]x") == "[abc][xX]"
+
+
+@pytest.mark.asyncio
+async def test_glob_smart_case_lowercase_matches_uppercase_file(tmp_path):
+    (tmp_path / "SOUL.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*soul*")
+    assert "SOUL.md" in result  # the original footgun, now fixed
+
+
+@pytest.mark.asyncio
+async def test_glob_uppercase_pattern_is_case_sensitive(tmp_path):
+    (tmp_path / "Readme.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    # lowercase -> smart insensitive -> matches
+    assert "Readme.md" in await tool.execute(pattern="*readme*")
+    # uppercase letter -> case-sensitive -> 'README' != 'Readme'
+    assert "Readme.md" not in await tool.execute(pattern="*README*")
+
+
+@pytest.mark.asyncio
+async def test_glob_explicit_case_sensitive(tmp_path):
+    (tmp_path / "SOUL.md").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="*soul*", case_insensitive=False)
+    assert result.startswith("No files matching")
+
+
+@pytest.mark.asyncio
+async def test_glob_smart_case_preserves_recursion(tmp_path):
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    (nested / "Config.yaml").write_text("x", encoding="utf-8")
+    tool = GlobTool(workspace=tmp_path)
+    result = await tool.execute(pattern="**/*config*")
+    assert "a/b/Config.yaml" in result  # ** recursion still works under smart-case
 
 
 # --------------------------- searching outside the workspace ---------------------------

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -161,9 +161,10 @@ async def test_grep_path_not_found(tmp_path):
 async def test_grep_ripgrep_missing_explicit(tmp_path, monkeypatch):
     _make_corpus(tmp_path)
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    tool = GrepTool(workspace=tmp_path, backend="ripgrep")
+    # auto_install=False keeps this deterministic (no network download attempt).
+    tool = GrepTool(workspace=tmp_path, backend="ripgrep", auto_install=False)
     result = await tool.execute(pattern="alpha")
-    assert "ripgrep" in result and "not installed" in result
+    assert "ripgrep" in result and "could not be installed" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -161,10 +161,31 @@ async def test_grep_path_not_found(tmp_path):
 async def test_grep_ripgrep_missing_explicit(tmp_path, monkeypatch):
     _make_corpus(tmp_path)
     monkeypatch.setattr(shutil, "which", lambda _: None)
-    # auto_install=False keeps this deterministic (no network download attempt).
-    tool = GrepTool(workspace=tmp_path, backend="ripgrep", auto_install=False)
+    # auto_install=False + sandboxed data_root keeps this deterministic (no download,
+    # no dependency on a binary cached in the real profile).
+    tool = GrepTool(
+        workspace=tmp_path, backend="ripgrep", auto_install=False, data_root=tmp_path
+    )
     result = await tool.execute(pattern="alpha")
     assert "ripgrep" in result and "could not be installed" in result
+
+
+def test_grep_rg_argv_disables_gitignore():
+    args = GrepTool._rg_argv("rg", "foo", ".", None, False, 0, "content")
+    assert "--no-ignore" in args  # do not honor .gitignore
+    assert "--hidden" in args  # search dotfiles too (matches Python fallback)
+    assert "!node_modules" in args  # but still prune known junk dirs
+    assert "!.git" in args
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
+async def test_grep_ripgrep_ignores_gitignore(tmp_path):
+    (tmp_path / ".gitignore").write_text("secret.txt\n", encoding="utf-8")
+    (tmp_path / "secret.txt").write_text("findme please\n", encoding="utf-8")
+    tool = GrepTool(workspace=tmp_path, backend="ripgrep", data_root=tmp_path)
+    result = await tool.execute(pattern="findme", output_mode="files_with_matches")
+    assert "secret.txt" in result  # gitignored file is still searched
 
 
 @pytest.mark.asyncio
@@ -174,8 +195,8 @@ async def test_grep_ripgrep_python_parity(tmp_path):
     corpus.mkdir()
     (corpus / "a.txt").write_text("alpha\nbeta\n", encoding="utf-8")
     (corpus / "b.txt").write_text("gamma\nalpha\n", encoding="utf-8")
-    rg_tool = GrepTool(workspace=tmp_path, backend="ripgrep")
-    py_tool = GrepTool(workspace=tmp_path, backend="python")
+    rg_tool = GrepTool(workspace=tmp_path, backend="ripgrep", data_root=tmp_path)
+    py_tool = GrepTool(workspace=tmp_path, backend="python", data_root=tmp_path)
     rg = await rg_tool.execute(pattern="alpha", path="clean", output_mode="files_with_matches")
     py = await py_tool.execute(pattern="alpha", path="clean", output_mode="files_with_matches")
     assert set(rg.splitlines()) == set(py.splitlines()) == {"a.txt", "b.txt"}

--- a/tests/test_visual_file_read.py
+++ b/tests/test_visual_file_read.py
@@ -427,3 +427,107 @@ class TestReadFileWindowing:
         f.write_text("one\ntwo\n", encoding="utf-8")
         result = await ReadFileTool(workspace=tmp_path).execute(path="t.txt")
         assert result == "one\ntwo\n"
+
+
+class TestEditFileRobust:
+    @pytest.mark.asyncio
+    async def test_exact_single(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("hello world", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="world", new_text="there"
+        )
+        assert "Successfully edited" in result
+        assert f.read_text() == "hello there"
+
+    @pytest.mark.asyncio
+    async def test_replace_all(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("a\na\na\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="a", new_text="X", replace_all=True
+        )
+        assert "3 replacement(s)" in result
+        assert f.read_text() == "X\nX\nX\n"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_without_replace_all_errors(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("a\na\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="a", new_text="X"
+        )
+        assert result.startswith("Error: old_text matches 2 locations")
+        assert f.read_text() == "a\na\n"  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_whitespace_tolerant_single(self, tmp_path):
+        f = tmp_path / "code.py"
+        f.write_text("def foo():\n        return 1\n", encoding="utf-8")  # 8-space indent
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="code.py",
+            old_text="def foo():\n    return 1",  # 4-space indent
+            new_text="def foo():\n    return 2",
+        )
+        assert "whitespace-tolerant" in result
+        assert f.read_text() == "def foo():\n    return 2\n"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_tolerant_ambiguous_errors(self, tmp_path):
+        f = tmp_path / "f.py"
+        f.write_text("if a:\n    do()\nif a:\n  do()\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.py", old_text="if a:\n do()", new_text="if a:\n done()"
+        )
+        assert "matches 2 locations after whitespace-tolerant" in result
+        assert f.read_text() == "if a:\n    do()\nif a:\n  do()\n"  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_whitespace_tolerant_not_found(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="gamma\ndelta", new_text="x"
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_crlf_preserved_on_untouched_lines(self, tmp_path):
+        f = tmp_path / "crlf.txt"
+        f.write_bytes(b"alpha\r\n    target\r\nomega\r\n")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="crlf.txt",
+            old_text="        target",  # 8-space indent forces the tolerant path
+            new_text="    target_done",
+        )
+        assert "whitespace-tolerant" in result
+        assert f.read_bytes() == b"alpha\r\n    target_done\r\nomega\r\n"
+
+    @pytest.mark.asyncio
+    async def test_identical_text_errors(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("same", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="same", new_text="same"
+        )
+        assert "identical" in result
+        assert f.read_text() == "same"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_old_text_errors(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("alpha\nbeta\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="   \n  ", new_text="x"
+        )
+        assert "only whitespace" in result
+
+    @pytest.mark.asyncio
+    async def test_deletion(self, tmp_path):
+        f = tmp_path / "f.txt"
+        f.write_text("keep\nremove me\nkeep\n", encoding="utf-8")
+        result = await EditFileTool(workspace=tmp_path).execute(
+            path="f.txt", old_text="remove me\n", new_text=""
+        )
+        assert "Successfully edited" in result
+        assert f.read_text() == "keep\nkeep\n"

--- a/tests/test_visual_file_read.py
+++ b/tests/test_visual_file_read.py
@@ -352,3 +352,78 @@ class TestLiteLLMSanitize:
         result = LiteLLMProvider._sanitize_messages(messages)
 
         assert result[0]["content"] == "hello"
+
+
+class TestReadFileWindowing:
+    @pytest.mark.asyncio
+    async def test_offset_and_limit_slice(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_text("\n".join(f"line{i}" for i in range(1, 51)), encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="big.txt", offset=5, limit=5)
+        body, _, footer = result.partition("\n\n[")
+        assert body.splitlines() == [f"line{i}" for i in range(5, 10)]
+        assert "showing lines 5-9 of 50" in footer
+        assert "offset=10" in footer
+
+    @pytest.mark.asyncio
+    async def test_limit_without_offset_starts_at_one(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_text("\n".join(f"line{i}" for i in range(1, 51)), encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="big.txt", limit=3)
+        assert result.split("\n\n[")[0].splitlines() == ["line1", "line2", "line3"]
+
+    @pytest.mark.asyncio
+    async def test_offset_past_eof(self, tmp_path):
+        f = tmp_path / "small.txt"
+        f.write_text("a\nb\nc", encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="small.txt", offset=99)
+        assert "past end of file" in result
+
+    @pytest.mark.asyncio
+    async def test_char_cap_and_footer(self, tmp_path):
+        f = tmp_path / "huge.txt"
+        # 1000 lines of 200 chars ~ 200k chars, well over the 50k cap
+        f.write_text("\n".join("x" * 200 for _ in range(1000)), encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="huge.txt")
+        assert len(result) < 60_000  # capped
+        assert "truncated at 50000-char cap" in result
+        assert "offset=" in result
+
+    @pytest.mark.asyncio
+    async def test_line_numbers_on_and_off(self, tmp_path):
+        f = tmp_path / "n.txt"
+        f.write_text("alpha\nbeta", encoding="utf-8")
+        plain = await ReadFileTool(workspace=tmp_path).execute(path="n.txt")
+        assert plain == "alpha\nbeta"
+        numbered = await ReadFileTool(workspace=tmp_path).execute(path="n.txt", line_numbers=True)
+        assert "1\talpha" in numbered
+        assert "2\tbeta" in numbered
+
+    @pytest.mark.asyncio
+    async def test_binary_file_graceful(self, tmp_path):
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"\x00\x01\x02\xff\xfe valid? no")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="blob.bin")
+        assert "not valid UTF-8" in result or "binary" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_file(self, tmp_path):
+        f = tmp_path / "empty.txt"
+        f.write_text("", encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="empty.txt")
+        assert result == "(file is empty)"
+
+    @pytest.mark.asyncio
+    async def test_small_file_no_footer(self, tmp_path):
+        f = tmp_path / "s.txt"
+        f.write_text("one\ntwo\nthree", encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="s.txt")
+        assert result == "one\ntwo\nthree"
+        assert "[showing lines" not in result
+
+    @pytest.mark.asyncio
+    async def test_trailing_newline_roundtrip(self, tmp_path):
+        f = tmp_path / "t.txt"
+        f.write_text("one\ntwo\n", encoding="utf-8")
+        result = await ReadFileTool(workspace=tmp_path).execute(path="t.txt")
+        assert result == "one\ntwo\n"


### PR DESCRIPTION
## Summary

- Add first-class `grep` (ripgrep-backed, with a pure-Python fallback) and `glob` (pathlib) search tools. The bot previously had no content/file search and had to shotgun `exec` + shell-grep, which broke on escaping, head-only truncation, and the workspace safety guard.
- When ripgrep is missing, `grep` auto-downloads the official BurntSushi binary into the profile data root on first use (mirroring the Chromium auto-install) and caches it; if the download fails it falls back to the Python backend.
- Search behaves predictably for an assistant: defaults to the workspace but accepts an absolute `path` to search anywhere on the machine; matching is smart-case; `.gitignore` is not honored so nothing is silently skipped; output lines over 64KB no longer crash the ripgrep backend.
- Harden `file_read` with `offset`/`limit` paging, a hard char/line cap plus a continuation footer, optional line numbers, and graceful binary/oversized handling — a bare read of a large file no longer blows the context window.
- Make `edit_file` robust: add `replace_all`, turn the ambiguous-match soft no-op into a hard error, and add an automatic whitespace/indentation-tolerant fallback that only applies to a single span (never edits the wrong spot); CRLF/LF preserved byte-for-byte.
- Add a `tools.search` config block (backend, caps, timeout, auto-install), register the tools across all registries (interactive, isolated cron/hook, and sub-agent), and document them plus a "File & Text Navigation Hierarchy" in the builtin prompt files.
