### PR TITLE
feat: hybrid recall search over memory and chats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ dependencies = [
     "ddgs>=9.0.0",
     "patchright>=1.40.0",
     "aiohttp>=3.9.0",
+    # recall (hybrid vector + BM25 search over memory & chats) — base install for zero-touch.
+    # No torch: ONNX Runtime CPU embeds EmbeddingGemma-300m (q4). The model and the
+    # sqlite-vec extension auto-download at runtime; these libs ship so it works out of the box.
+    "onnxruntime>=1.20.0",
+    "tokenizers>=0.20.0",
+    "sqlite-vec>=0.1.6",
+    "numpy>=1.26.0",
 ]
 
 [project.optional-dependencies]

--- a/ragnarbot/agent/index/__init__.py
+++ b/ragnarbot/agent/index/__init__.py
@@ -1,0 +1,42 @@
+"""Hybrid (dense vector + BM25) recall index over memory files and chats.
+
+Local, zero-touch: EmbeddingGemma-300m (q4 ONNX) runs on ONNX Runtime CPU and the
+sqlite-vec extension + model auto-download on first use. Indexing runs in the
+background on the same triggers as the memory-flush subsystem.
+
+This package is intentionally import-light at module load: heavy deps (onnxruntime,
+the model) are touched only when the embedder/store are actually constructed, so a
+profile that never uses recall pays nothing at import time.
+"""
+
+# ── model / embedding constants ─────────────────────────────────────
+EMBED_DIM = 768  # full Matryoshka dim; changing it invalidates all vectors (part of model_key)
+MODEL_REPO = "onnx-community/embeddinggemma-300m-ONNX"
+
+# quant -> ONNX filename inside the repo. q4 is the measured default (lowest RSS).
+QUANT_FILES = {
+    "q4": "onnx/model_q4.onnx",
+    "q8": "onnx/model_quantized.onnx",  # int8 dynamic — heavier on CPU, kept selectable
+    "fp16": "onnx/model_fp16.onnx",
+    "fp32": "onnx/model.onnx",
+}
+# external-weights sidecar that always accompanies the .onnx for this export
+ONNX_DATA_SUFFIX = "_data"
+TOKENIZER_FILES = ("tokenizer.json", "config.json")
+
+# Asymmetric task prefixes (required for EmbeddingGemma retrieval quality).
+DOC_PREFIX = "title: none | text: "
+QUERY_PREFIX = "task: search result | query: "
+
+# ── chunking constants ──────────────────────────────────────────────
+MAX_TOKENS = 512          # hard cap per chunk (model context budget for a unit)
+TARGET_TOKENS = 400       # preferred chunk size
+OVERLAP_TOKENS = 60       # overlap carried between adjacent chunks
+MIN_CHUNK_TOKENS = 32     # floor; smaller tails get merged
+MAX_TURNS = 6             # max conversation turns packed into one chat chunk
+SPECIAL_HEADROOM = 4      # budget slack for BOS/EOS the embedder adds vs the chunker count
+
+
+def model_key(quant: str) -> str:
+    """Identity of the embedding space; bumped invalidates cached vectors/chunks."""
+    return f"embeddinggemma-300m/{quant}/{EMBED_DIM}"

--- a/ragnarbot/agent/index/chat_chunking.py
+++ b/ragnarbot/agent/index/chat_chunking.py
@@ -1,0 +1,270 @@
+"""Chat-session normalization + Q->A chunking for the recall index.
+
+Chats are structured messages, not plain text. We strip tool noise, unwrap voice
+transcriptions, keep genuine user/assistant utterances (and substantive captions),
+index compaction summaries standalone, then pack consecutive Q->A turns into
+<=6-turn / <=512-token chunks. ``finalize()`` (chunking.py) is the hard cap backstop.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from ragnarbot.agent.index import (
+    DOC_PREFIX,
+    MAX_TOKENS,
+    MAX_TURNS,
+    OVERLAP_TOKENS,
+    SPECIAL_HEADROOM,
+    chunking,
+)
+
+_VOICE_OK = re.compile(r"^\[Voice message transcription:\s*(.*)\]$", re.S)
+_VOICE_BAD = re.compile(r"^\[(?:Voice message|voice:|audio:)", re.I)
+_OPS_ASSISTANT = re.compile(r"^\[(?:Cron result|Hook triggered|Heartbeat)", re.I)
+_MEDIA_MARKER = re.compile(r"^\[(?:photo|file|image|empty)\b", re.I)
+_SYS_DROP = ("background", "gateway", "update", "poll", "heartbeat")
+_SUMMARY_PREFIX = "[Conversation Summary]"
+
+
+@dataclass
+class Turn:
+    role: str          # user | assistant | summary | system
+    text: str
+    ts: str | None
+    idx: int
+    used_tools: tuple[str, ...] = ()
+
+
+@dataclass
+class Pair:
+    turns: list[Turn]
+    kind: str          # qa | q_only | a_only | summary | system
+    scope_kind: str = field(init=False)
+
+    def __post_init__(self):
+        self.scope_kind = self.kind if self.kind in ("summary", "system") else "qa"
+
+
+# ── normalization (§8.1) ────────────────────────────────────────────
+
+def _flatten(content) -> str:
+    if isinstance(content, list):
+        parts = [b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        return " ".join(p for p in parts if p)
+    return content or ""
+
+
+def _strip_media_markers(text: str) -> str:
+    keep = [ln for ln in text.split("\n") if not _MEDIA_MARKER.match(ln.strip())]
+    return "\n".join(keep).strip()
+
+
+def _is_substantive_caption(text: str) -> bool:
+    """Keep a caption (assistant text alongside a tool_call) only if it carries signal."""
+    return bool(re.search(r"\d|https?://", text)) or len(text.split()) >= 12
+
+
+def normalize(messages: list[dict], start: int, end: int) -> list[Turn]:
+    turns: list[Turn] = []
+    for i in range(start, min(end, len(messages))):
+        m = messages[i]
+        meta = m.get("metadata", {}) or {}
+        typ = meta.get("type")
+        ts = meta.get("timestamp")
+        content = _flatten(m.get("content")).strip()
+        role = m.get("role")
+
+        if typ == "compaction":
+            body = content
+            if body.startswith(_SUMMARY_PREFIX):
+                body = body[len(_SUMMARY_PREFIX):].lstrip("\n").strip()
+            if body:
+                turns.append(Turn("summary", body, ts, i))
+            continue
+
+        if role == "tool":
+            continue
+
+        if role == "user":
+            mv = _VOICE_OK.match(content)
+            if mv:
+                content = mv.group(1).strip()
+            elif _VOICE_BAD.match(content):
+                continue  # failed/empty voice
+            if content.startswith("[System:"):
+                low = content.lower()
+                if any(k in low for k in _SYS_DROP):
+                    continue
+                turns.append(Turn("system", content, ts, i))
+                continue
+            content = _strip_media_markers(content)
+            if content:
+                turns.append(Turn("user", content, ts, i))
+            continue
+
+        if role == "assistant":
+            if _OPS_ASSISTANT.match(content):
+                continue
+            tools = tuple(
+                tc.get("function", {}).get("name", "")
+                for tc in (m.get("tool_calls") or [])
+            )
+            if tools:
+                if content and _is_substantive_caption(content):
+                    turns.append(Turn("assistant", content, ts, i, used_tools=tools))
+                continue  # tool-only cycle (or non-substantive caption) -> drop text
+            if content:
+                turns.append(Turn("assistant", content, ts, i))
+            continue
+    return turns
+
+
+# ── pairing (§8.3) ──────────────────────────────────────────────────
+
+def pair_turns(turns: list[Turn]) -> list[Pair]:
+    pairs: list[Pair] = []
+    i, n = 0, len(turns)
+    while i < n:
+        t = turns[i]
+        if t.role in ("summary", "system"):
+            pairs.append(Pair([t], t.role))
+            i += 1
+            continue
+        burst: list[Turn] = []
+        n_user = 0
+        while i < n and turns[i].role == "user":
+            burst.append(turns[i])
+            n_user += 1
+            i += 1
+        n_asst = 0
+        while i < n and turns[i].role == "assistant":
+            burst.append(turns[i])
+            n_asst += 1
+            i += 1
+        if not burst:
+            i += 1
+            continue
+        if n_user and n_asst:
+            kind = "qa"
+        elif n_user:
+            kind = "q_only"
+        else:
+            kind = "a_only"
+        pairs.append(Pair(burst, kind))
+    return pairs
+
+
+# ── packing + rendering (§8.3 / §8.4) ───────────────────────────────
+
+def _hard() -> int:
+    overhead = chunking.count_tokens(DOC_PREFIX, special=True) + SPECIAL_HEADROOM
+    return MAX_TOKENS - overhead - 8  # small margin for the time header line
+
+
+def _label(role: str, user_name: str) -> str:
+    return {"user": user_name, "assistant": "Assistant", "summary": "Summary",
+            "system": "System"}.get(role, role.title())
+
+
+def _time_header(turns: list[Turn]) -> str:
+    ts = [t.ts for t in turns if t.ts]
+    if not ts:
+        return ""
+    lo, hi = min(ts), max(ts)
+    a, b = lo[:16].replace("T", " "), hi[:16].replace("T", " ")
+    return f"[{a}]" if a == b else f"[{a} … {b}]"
+
+
+def _render(turns: list[Turn], user_name: str) -> str:
+    lines = []
+    header = _time_header(turns)
+    if header:
+        lines.append(header)
+    for t in turns:
+        lines.append(f"{_label(t.role, user_name)}: {t.text}")
+    return "\n".join(lines)
+
+
+def _carry(turns: list[Turn]) -> list[Turn]:
+    """Trailing turns to repeat as overlap into the next chunk (<= OVERLAP_TOKENS)."""
+    if not turns:
+        return []
+    last = turns[-1]
+    return [last] if chunking.count_tokens(last.text) <= OVERLAP_TOKENS else []
+
+
+def chunk_chat_segment(
+    messages: list[dict],
+    start: int,
+    end: int,
+    meta: dict,
+    model_key: str,
+) -> list[dict]:
+    """Normalize + chunk a session range [start, end) into store rows (no embeddings)."""
+    turns = normalize(messages, start, end)
+    if not turns:
+        return []
+    pairs = pair_turns(turns)
+    hard = _hard()
+    user_name = meta.get("user_name") or "User"
+
+    groups: list[tuple[list[Turn], str]] = []
+    buf: list[Turn] = []
+    for pair in pairs:
+        if pair.scope_kind in ("summary", "system"):
+            if buf:
+                groups.append((buf, "qa"))
+                buf = []
+            groups.append((pair.turns, pair.scope_kind))
+            continue
+        if buf and (
+            len(buf) + len(pair.turns) > MAX_TURNS
+            or chunking.count_tokens(_render(buf + pair.turns, user_name)) > hard
+        ):
+            groups.append((buf, "qa"))
+            buf = _carry(buf)
+        buf = buf + pair.turns
+    if buf:
+        groups.append((buf, "qa"))
+
+    rows: list[dict] = []
+    for turns_g, scope_kind in groups:
+        for sub in _split_turns(turns_g):           # enforce <= MAX_TURNS per chunk
+            body = _render(sub, user_name)
+            for piece in chunking.finalize(body):   # hard <=512 guarantee (reflow if needed)
+                rows.append(_row(sub, piece, scope_kind, len(rows), meta, model_key))
+    return rows
+
+
+def _split_turns(turns: list[Turn]) -> list[list[Turn]]:
+    if len(turns) <= MAX_TURNS:
+        return [turns]
+    return [turns[i:i + MAX_TURNS] for i in range(0, len(turns), MAX_TURNS)]
+
+
+def _row(turns: list[Turn], body: str, scope_kind: str, chunk_index: int,
+         meta: dict, model_key: str) -> dict:
+    ts = [t.ts for t in turns if t.ts]
+    ts_start, ts_end = (min(ts), max(ts)) if ts else (None, None)
+    idxs = [t.idx for t in turns]
+    tools = sorted({name for t in turns for name in t.used_tools if name})
+    return {
+        "corpus": "chat",
+        "source_id": meta["source_id"],
+        "chunk_hash": chunking.chunk_hash(body, model_key),
+        "body": body,
+        "source_path": meta.get("source_path"),
+        "scope_kind": scope_kind,
+        "dialogue_id": meta.get("dialogue_id") or meta["source_id"],
+        "user_key": meta.get("user_key"),
+        "day_start": ts_start[:10] if ts_start else None,
+        "day_end": ts_end[:10] if ts_end else None,
+        "ts_start": ts_start,
+        "ts_end": ts_end,
+        "chunk_index": chunk_index,
+        "used_tools": ", ".join(tools) if tools else None,
+        "msg_start": min(idxs) if idxs else None,
+        "msg_end": max(idxs) if idxs else None,
+    }

--- a/ragnarbot/agent/index/chunking.py
+++ b/ragnarbot/agent/index/chunking.py
@@ -1,0 +1,224 @@
+"""Tokenizer-accurate text chunking for the recall index.
+
+The tokenizer is injected once (the embedder's real ``tokenizers.Tokenizer``) so
+budgeting uses the *same* counts the model sees — never ``len // 4``, which
+under-counts Cyrillic 2-3x and would silently blow the 512 cap. The 512 ceiling is
+enforced on the actual embedded artifact (``finalize``), not on a sum of fragment
+counts (SentencePiece is non-additive).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from ragnarbot.agent.index import (
+    DOC_PREFIX,
+    MAX_TOKENS,
+    MIN_CHUNK_TOKENS,
+    OVERLAP_TOKENS,
+    SPECIAL_HEADROOM,
+    TARGET_TOKENS,
+)
+
+_SEPS = ["\n\n", "\n", ". ", " "]
+_TOK = None  # injected tokenizers.Tokenizer
+
+
+def set_tokenizer(tok) -> None:
+    """Inject the embedder's tokenizer (must expose encode(...).ids and decode())."""
+    global _TOK
+    _TOK = tok
+
+
+def _require_tok():
+    if _TOK is None:
+        raise RuntimeError("chunking tokenizer not set; call set_tokenizer() first")
+    return _TOK
+
+
+def count_tokens(text: str, *, special: bool = False) -> int:
+    return len(_require_tok().encode(text, add_special_tokens=special).ids)
+
+
+def token_windows(text: str, limit: int, overlap: int = 0) -> list[str]:
+    """Last-resort splitter: fixed windows over token ids (never per-character)."""
+    tok = _require_tok()
+    ids = tok.encode(text, add_special_tokens=False).ids
+    if len(ids) <= limit:
+        return [text]
+    step = max(1, limit - overlap)
+    out = []
+    for i in range(0, len(ids), step):
+        piece = tok.decode(ids[i:i + limit]).strip()
+        if piece:
+            out.append(piece)
+        if i + limit >= len(ids):
+            break
+    return out or [text]
+
+
+def recursive_split(text: str, limit: int, seps: list[str] | None = None) -> list[str]:
+    """Split text so every part is <= limit tokens, preferring natural boundaries."""
+    if count_tokens(text) <= limit:
+        return [text]
+    seps = _SEPS if seps is None else seps
+    if not seps:
+        return token_windows(text, limit, overlap=0)
+
+    sep, rest = seps[0], seps[1:]
+    parts = [p for p in text.split(sep) if p != ""]
+    if len(parts) <= 1:
+        return recursive_split(text, limit, rest)
+
+    out: list[str] = []
+    for p in parts:
+        if count_tokens(p) <= limit:
+            out.append(p)
+        else:
+            out.extend(recursive_split(p, limit, rest))
+    return out
+
+
+def _overhead_tokens(breadcrumb: str | None) -> int:
+    pre = DOC_PREFIX + (breadcrumb + "\n\n" if breadcrumb else "")
+    return count_tokens(pre, special=True) + SPECIAL_HEADROOM
+
+
+def finalize(body: str, breadcrumb: str | None = None) -> list[str]:
+    """Re-measure the real embedded artifact; reflow into <=MAX_TOKENS bodies."""
+    artifact = DOC_PREFIX + (breadcrumb + "\n\n" if breadcrumb else "") + body
+    if count_tokens(artifact, special=True) <= MAX_TOKENS:
+        return [body]
+    available = max(MIN_CHUNK_TOKENS, MAX_TOKENS - _overhead_tokens(breadcrumb))
+    return token_windows(body, available, overlap=min(OVERLAP_TOKENS, available // 4))
+
+
+def normalize_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def chunk_hash(body: str, model_key: str) -> str:
+    h = hashlib.sha256((normalize_ws(body) + "\x00" + model_key).encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+# ── memory-dump (Markdown) chunking ─────────────────────────────────
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+
+
+def _parse_blocks(text: str) -> list[dict]:
+    """Ordered content blocks, each carrying its live heading_path.
+
+    Headings are prepended to the following content block (sticky — never stranded
+    as a chunk tail) and kept inline so FTS sees section names.
+    """
+    blocks: list[dict] = []
+    stack: dict[int, str] = {}
+    pending: list[str] = []
+    buf: list[str] = []
+
+    def heading_path() -> str:
+        return " > ".join(stack[lvl] for lvl in sorted(stack))
+
+    def flush_buf():
+        if not buf:
+            return
+        body = "".join(buf).strip()
+        buf.clear()
+        if not body:
+            return
+        text_out = ("\n".join(pending) + "\n" + body) if pending else body
+        blocks.append({"text": text_out, "heading_path": heading_path()})
+        pending.clear()
+
+    for line in text.splitlines():
+        m = _HEADING_RE.match(line.strip())
+        if m:
+            flush_buf()
+            level, title = len(m.group(1)), m.group(2).strip()
+            for lvl in [x for x in stack if x >= level]:
+                del stack[lvl]
+            stack[level] = title
+            pending.append(line.strip())
+        elif line.strip() == "":
+            flush_buf()
+        else:
+            buf.append(line)
+    flush_buf()
+    # trailing heading(s) with no content
+    if pending:
+        blocks.append({"text": "\n".join(pending), "heading_path": heading_path()})
+    return blocks
+
+
+def chunk_memory_file(
+    text: str,
+    *,
+    source_id: str,
+    source_path: str,
+    scope_kind: str,
+    day: str,
+    model_key: str,
+) -> list[dict]:
+    """Chunk a memory Markdown file into <=512-token store rows (no embeddings yet)."""
+    blocks = _parse_blocks(text)
+    # split oversized blocks up front
+    segments: list[dict] = []
+    for b in blocks:
+        if count_tokens(b["text"]) <= MAX_TOKENS:
+            segments.append(b)
+        else:
+            for piece in recursive_split(b["text"], TARGET_TOKENS):
+                segments.append({"text": piece, "heading_path": b["heading_path"]})
+
+    chunks_raw: list[dict] = []
+    cur: list[dict] = []
+    cur_tok = 0
+    started_with_overlap = False
+
+    def emit(group: list[dict], overlap_started: bool):
+        if not group:
+            return
+        body = "\n\n".join(s["text"] for s in group)
+        hpath = group[0]["heading_path"]
+        is_continuation = bool(chunks_raw) and (overlap_started or not body.lstrip().startswith("#"))
+        breadcrumb = hpath if (is_continuation and hpath) else None
+        for piece in finalize(body, breadcrumb):
+            chunks_raw.append({"body": piece, "heading_path": hpath, "breadcrumb": breadcrumb})
+
+    for seg in segments:
+        st = count_tokens(seg["text"])
+        if cur and cur_tok + st > MAX_TOKENS:
+            emit(cur, started_with_overlap)
+            carry = cur[-1:] if count_tokens(cur[-1]["text"]) <= OVERLAP_TOKENS else []
+            cur = list(carry)
+            cur_tok = sum(count_tokens(s["text"]) for s in cur)
+            started_with_overlap = bool(carry)
+        cur.append(seg)
+        cur_tok += st
+        if cur_tok >= TARGET_TOKENS:
+            emit(cur, started_with_overlap)
+            carry = cur[-1:] if count_tokens(cur[-1]["text"]) <= OVERLAP_TOKENS else []
+            cur = list(carry)
+            cur_tok = sum(count_tokens(s["text"]) for s in cur)
+            started_with_overlap = bool(carry)
+    emit(cur, started_with_overlap)
+
+    day_val = "" if scope_kind == "long_term" else day
+    rows: list[dict] = []
+    for idx, c in enumerate(chunks_raw):
+        rows.append({
+            "corpus": "memory",
+            "source_id": source_id,
+            "chunk_hash": chunk_hash(c["body"], model_key),
+            "body": c["body"],
+            "source_path": source_path,
+            "scope_kind": scope_kind,
+            "day_start": day_val,
+            "day_end": day_val,
+            "heading_path": c["heading_path"] or None,
+            "chunk_index": idx,
+        })
+    return rows

--- a/ragnarbot/agent/index/embedder.py
+++ b/ragnarbot/agent/index/embedder.py
@@ -1,0 +1,91 @@
+"""EmbeddingGemma-300m embedder on ONNX Runtime (CPU).
+
+The pinned export emits a pooled ``sentence_embedding`` output (masked-mean-pool +
+both dense projection layers baked in), so embedding is: run the session, take that
+output, L2-normalize — no external pooling. Asymmetric task prefixes are applied at
+embed time only (never stored). Query and batch-index inference run on separate
+single-thread executors so a user query never queues behind a backfill batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+from ragnarbot.agent.index import DOC_PREFIX, EMBED_DIM, QUERY_PREFIX
+from ragnarbot.agent.index.provision import onnx_path
+
+# Hard ceiling for any single input fed to the model (model context is 2048;
+# chunks are <=512 by construction, but guard against pathological queries).
+_TRUNCATE_TOKENS = 2048
+
+
+class Embedder:
+    """Wraps an ONNX session + tokenizer; produces L2-normalized 768-d vectors."""
+
+    def __init__(self, model_dir: Path, quant: str = "q4"):
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+
+        self._session = ort.InferenceSession(
+            str(onnx_path(model_dir, quant)), providers=["CPUExecutionProvider"]
+        )
+        out_names = [o.name for o in self._session.get_outputs()]
+        if "sentence_embedding" not in out_names:
+            raise RuntimeError("ONNX export lacks 'sentence_embedding' output")
+        self._in_names = {i.name for i in self._session.get_inputs()}
+
+        self.tokenizer = Tokenizer.from_file(str(model_dir / "tokenizer.json"))
+        self.tokenizer.enable_truncation(max_length=_TRUNCATE_TOKENS)
+
+        self._query_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="recall-embed-q")
+        self._index_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="recall-embed-i")
+
+    # ── token counting (shared with the chunker for budget parity) ──
+    def count_tokens(self, text: str) -> int:
+        return len(self.tokenizer.encode(text, add_special_tokens=False).ids)
+
+    # ── sync embedding ──────────────────────────────────────────────
+    def _run(self, texts: list[str]) -> np.ndarray:
+        encs = self.tokenizer.encode_batch(texts)
+        maxlen = max((len(e.ids) for e in encs), default=1)
+        ids = np.zeros((len(encs), maxlen), dtype=np.int64)
+        mask = np.zeros((len(encs), maxlen), dtype=np.int64)
+        for i, e in enumerate(encs):
+            n = len(e.ids)
+            ids[i, :n] = e.ids
+            mask[i, :n] = 1
+
+        feed: dict = {"input_ids": ids, "attention_mask": mask}
+        if "token_type_ids" in self._in_names:
+            feed["token_type_ids"] = np.zeros_like(ids)
+        if "position_ids" in self._in_names:
+            feed["position_ids"] = np.clip(np.cumsum(mask, axis=1) - 1, 0, None).astype(np.int64)
+
+        out = self._session.run(["sentence_embedding"], feed)[0].astype(np.float32)
+        norms = np.clip(np.linalg.norm(out, axis=1, keepdims=True), 1e-9, None)
+        return out / norms
+
+    def embed_documents(self, texts: list[str]) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, EMBED_DIM), dtype=np.float32)
+        return self._run([DOC_PREFIX + t for t in texts])
+
+    def embed_query(self, text: str) -> np.ndarray:
+        return self._run([QUERY_PREFIX + text])[0]
+
+    # ── async wrappers on dedicated lanes ───────────────────────────
+    async def aembed_documents(self, texts: list[str]) -> np.ndarray:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._index_pool, self.embed_documents, texts)
+
+    async def aembed_query(self, text: str) -> np.ndarray:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._query_pool, self.embed_query, text)
+
+    def close(self) -> None:
+        self._query_pool.shutdown(wait=False, cancel_futures=True)
+        self._index_pool.shutdown(wait=False, cancel_futures=True)

--- a/ragnarbot/agent/index/manager.py
+++ b/ragnarbot/agent/index/manager.py
@@ -1,0 +1,323 @@
+"""IndexManager — background indexing + search, a sibling of MemoryFlushManager.
+
+Chat jobs are durable (session.metadata["vector_index"]["jobs"], idempotent by
+fingerprint) and reuse the memory-flush trigger points. Memory re-index runs as
+transient tasks (files persist on disk; the startup scan is the safety net). All
+heavy work (embed/chunk/DB) happens in the background — the hot path only does a
+metadata append + a non-blocking task spawn, and every public hot-path method is
+defensively never-raise so a recall bug can never crash a turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from pathlib import Path
+from typing import Callable
+
+from loguru import logger
+
+from ragnarbot.agent.index import chat_chunking, chunking, model_key
+from ragnarbot.agent.index.embedder import Embedder
+from ragnarbot.agent.index.provision import ensure_embedding_model, sqlite_vec_supported
+from ragnarbot.agent.index.store import Store
+from ragnarbot.agent.memory import MemoryStore
+from ragnarbot.utils.helpers import get_index_dir, get_memory_path, get_models_dir
+
+_META_KEY = "vector_index"
+_JOBS_KEY = "jobs"
+_MAX_RETRIES = 3
+_RETRY_DELAY = 5
+_EMBED_BATCH = 64
+
+
+class IndexManager:
+    def __init__(self, sessions, config, save_session_fn: Callable, workspace: Path):
+        self.sessions = sessions
+        self._cfg = config
+        self._save_session_fn = save_session_fn
+        self.workspace = workspace
+        self._memory = MemoryStore(workspace)
+
+        self._store: Store | None = None
+        self._embedder: Embedder | None = None
+        self._fail_reason: str | None = None
+        self._init_lock = asyncio.Lock()
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._mem_tasks: set[asyncio.Task] = set()
+
+    # ── readiness / provisioning ────────────────────────────────────
+    def available(self) -> bool:
+        return self._store is not None and self._embedder is not None
+
+    def status(self) -> str:
+        if self._fail_reason:
+            return f"Recall is unavailable: {self._fail_reason}"
+        if not getattr(self._cfg, "enabled", True):
+            return "Recall is disabled in config."
+        return "The recall index is still preparing (downloading the embedding model). Try again shortly."
+
+    async def _ensure_ready(self) -> bool:
+        if self.available():
+            return True
+        if self._fail_reason is not None:
+            return False
+        async with self._init_lock:
+            if self.available():
+                return True
+            if self._fail_reason is not None:
+                return False
+            try:
+                if not getattr(self._cfg, "enabled", True):
+                    self._fail_reason = "disabled in config"
+                    return False
+                if not sqlite_vec_supported():
+                    self._fail_reason = (
+                        "this Python build cannot load SQLite extensions "
+                        "(use a Homebrew/uv CPython 3.11+)"
+                    )
+                    logger.warning("recall disabled: {}", self._fail_reason)
+                    return False
+                model_dir = await ensure_embedding_model(
+                    get_models_dir(),
+                    quant=getattr(self._cfg, "quant", "q4"),
+                    rev=getattr(self._cfg, "embed_rev", None) or _default_rev(),
+                    allow_download=getattr(self._cfg, "auto_install", True),
+                )
+                if model_dir is None:
+                    self._fail_reason = "embedding model could not be provisioned"
+                    return False
+                embedder = Embedder(model_dir, getattr(self._cfg, "quant", "q4"))
+                chunking.set_tokenizer(embedder.tokenizer)
+                store = Store(get_index_dir() / "recall.db")
+                await store.open()
+                if not await store.self_test():
+                    self._fail_reason = "index self-test failed"
+                    return False
+                self._embedder, self._store = embedder, store
+                logger.info("recall index ready")
+                return True
+            except Exception as exc:
+                self._fail_reason = str(exc)
+                logger.warning("recall provisioning failed: {}", exc)
+                return False
+
+    # ── search ──────────────────────────────────────────────────────
+    async def search(self, query: str, *, scope="both", top_k=8,
+                     date_from=None, date_to=None, dialogue_id=None) -> list[dict]:
+        if not await self._ensure_ready():
+            raise RuntimeError(self._fail_reason or "index not ready")
+        vec = await self._embedder.aembed_query(query)
+        return await self._store.hybrid_search(
+            vec, query, scope=scope, top_k=top_k,
+            rrf_k=getattr(self._cfg, "rrf_k", 60),
+            date_from=date_from, date_to=date_to, dialogue_id=dialogue_id,
+        )
+
+    # ── chat indexing (hot path: never-raise) ───────────────────────
+    def enqueue_chat_segment(self, session, segment) -> None:
+        try:
+            if not getattr(self._cfg, "enabled", True):
+                return
+            self._enqueue(session, segment.start_idx, segment.end_idx)
+        except Exception as exc:
+            logger.warning("recall enqueue_chat_segment failed: {}", exc)
+
+    def _enqueue(self, session, start_idx: int, end_idx: int) -> bool:
+        if end_idx <= start_idx:
+            return False
+        state = session.metadata.setdefault(_META_KEY, {})
+        jobs = state.setdefault(_JOBS_KEY, [])
+        fp = f"chat:{session.key}:{start_idx}:{end_idx}"
+        if any(j.get("fingerprint") == fp for j in jobs):
+            return False
+        jobs.append({
+            "id": uuid.uuid4().hex[:12],
+            "fingerprint": fp,
+            "start_idx": start_idx,
+            "end_idx": end_idx,
+            "status": "pending",
+            "attempts": 0,
+        })
+        return True
+
+    async def start_chat_jobs(self, session) -> None:
+        try:
+            jobs = session.metadata.get(_META_KEY, {}).get(_JOBS_KEY, [])
+            for job in jobs:
+                if job.get("status") not in ("pending", "error"):
+                    continue
+                jid = job["id"]
+                if jid in self._tasks:
+                    continue
+                task = asyncio.create_task(self._run_chat_job(session.key, jid))
+                self._tasks[jid] = task
+                task.add_done_callback(lambda _, j=jid: self._tasks.pop(j, None))
+        except Exception as exc:
+            logger.warning("recall start_chat_jobs failed: {}", exc)
+
+    async def _run_chat_job(self, session_key: str, job_id: str) -> None:
+        if not await self._ensure_ready():
+            return  # stays pending; retried by next trigger/backfill
+        session = self.sessions.get_by_id(session_key)
+        if session is None:
+            return
+        job = _find_job(session, job_id)
+        if job is None:
+            return
+        try:
+            job["status"] = "running"
+            meta = {
+                "source_id": session.key,
+                "dialogue_id": session.key,
+                "source_path": str((self.sessions.chats_dir / f"{session.key}.jsonl")),
+                "user_key": session.user_key,
+                "user_name": session.metadata.get("user_name") or "User",
+            }
+            rows = chat_chunking.chunk_chat_segment(
+                session.messages, job["start_idx"], job["end_idx"], meta, model_key(self._quant()),
+            )
+            await self._embed_and_upsert(rows)
+            job["status"] = "done"
+            await self._store.set_state(
+                f"chat:{session.key}", model_key=model_key(self._quant()),
+                indexed_upto=max(job["end_idx"], _state_cursor(session)),
+            )
+            session.metadata[_META_KEY]["cursor"] = max(job["end_idx"], _state_cursor(session))
+            await self._save_session_fn(session)
+        except Exception as exc:
+            logger.warning("recall chat job {} failed: {}", job_id, exc)
+            await self._mark_error_and_retry(session_key, job_id)
+
+    async def _mark_error_and_retry(self, session_key: str, job_id: str) -> None:
+        session = self.sessions.get_by_id(session_key)
+        if session is None:
+            return
+        job = _find_job(session, job_id)
+        if job is None:
+            return
+        job["attempts"] = int(job.get("attempts", 0)) + 1
+        job["status"] = "error"
+        await self._save_session_fn(session)
+        if job["attempts"] < _MAX_RETRIES:
+            asyncio.create_task(self._retry_later(session_key, job_id, job["attempts"]))
+
+    async def _retry_later(self, session_key: str, job_id: str, attempts: int) -> None:
+        await asyncio.sleep(_RETRY_DELAY * max(1, attempts))
+        session = self.sessions.get_by_id(session_key)
+        if session is not None:
+            await self.start_chat_jobs(session)
+
+    # ── memory indexing (transient tasks) ───────────────────────────
+    def on_memory_written(self, scope: str, date: str | None) -> None:
+        try:
+            if not getattr(self._cfg, "enabled", True):
+                return
+            path = self._memory.memory_file if scope == "long_term" else self._memory.get_day_file(date)
+            task = asyncio.create_task(self._reindex_memory(Path(path), scope, date))
+            self._mem_tasks.add(task)
+            task.add_done_callback(self._mem_tasks.discard)
+        except Exception as exc:
+            logger.warning("recall on_memory_written failed: {}", exc)
+
+    async def _reindex_memory(self, path: Path, scope: str, date: str | None) -> None:
+        if not await self._ensure_ready():
+            return
+        try:
+            key = f"memory:{path}"
+            if not path.exists():
+                await self._store.delete_source("memory", str(path))
+                return
+            data = path.read_bytes()
+            digest = hashlib.sha256(data).hexdigest()
+            mk = model_key(self._quant())
+            state = await self._store.get_state(key)
+            if state and state["content_hash"] == digest and state["model_key"] == mk:
+                return  # GATE 1: unchanged
+            rows = chunking.chunk_memory_file(
+                data.decode("utf-8", "ignore"),
+                source_id=str(path), source_path=str(path),
+                scope_kind=scope, day=date or "", model_key=mk,
+            )
+            await self._embed_rows(rows)
+            await self._store.replace_source("memory", str(path), rows)
+            await self._store.set_state(key, content_hash=digest, model_key=mk)
+        except Exception as exc:
+            logger.warning("recall memory reindex of {} failed: {}", path, exc)
+
+    async def _scan_memory(self) -> None:
+        mem_dir = get_memory_path(self.workspace)
+        for f in sorted(mem_dir.glob("????-??-??.md")):
+            await self._reindex_memory(f, "daily", f.stem)
+        mfile = self._memory.memory_file
+        if mfile.exists():
+            await self._reindex_memory(mfile, "long_term", None)
+
+    # ── startup resume + backfill ───────────────────────────────────
+    async def resume_and_backfill(self) -> None:
+        try:
+            if not getattr(self._cfg, "enabled", True):
+                return
+            if not await self._ensure_ready():
+                return
+            for info in self.sessions.list_sessions():
+                sid = info.get("session_id")
+                if not sid:
+                    continue
+                session = self.sessions.get_by_id(sid)
+                if session is None:
+                    continue
+                cursor = await self._chat_cursor(session.key)
+                n = len(session.messages)
+                changed = self._enqueue(session, cursor, n) if n > cursor else False
+                # also re-queue any leftover pending/error jobs
+                if changed:
+                    await self._save_session_fn(session)
+                await self.start_chat_jobs(session)
+            await self._scan_memory()
+        except Exception as exc:
+            logger.warning("recall resume_and_backfill failed: {}", exc)
+
+    async def _chat_cursor(self, session_key: str) -> int:
+        state = await self._store.get_state(f"chat:{session_key}")
+        return int(state["indexed_upto"]) if state and state.get("indexed_upto") else 0
+
+    # ── helpers ─────────────────────────────────────────────────────
+    def _quant(self) -> str:
+        return getattr(self._cfg, "quant", "q4")
+
+    async def _embed_and_upsert(self, rows: list[dict]) -> int:
+        if not rows:
+            return 0
+        await self._embed_rows(rows)
+        return await self._store.upsert(rows)
+
+    async def _embed_rows(self, rows: list[dict]) -> None:
+        for i in range(0, len(rows), _EMBED_BATCH):
+            batch = rows[i:i + _EMBED_BATCH]
+            vecs = await self._embedder.aembed_documents([r["body"] for r in batch])
+            for r, v in zip(batch, vecs):
+                r["embedding"] = v
+
+    async def close(self) -> None:
+        if self._store is not None:
+            await self._store.close()
+        if self._embedder is not None:
+            self._embedder.close()
+
+
+def _find_job(session, job_id: str) -> dict | None:
+    for job in session.metadata.get(_META_KEY, {}).get(_JOBS_KEY, []):
+        if job.get("id") == job_id:
+            return job
+    return None
+
+
+def _state_cursor(session) -> int:
+    return int(session.metadata.get(_META_KEY, {}).get("cursor", 0))
+
+
+def _default_rev() -> str:
+    from ragnarbot.agent.index.provision import DEFAULT_REV
+    return DEFAULT_REV

--- a/ragnarbot/agent/index/provision.py
+++ b/ragnarbot/agent/index/provision.py
@@ -1,0 +1,198 @@
+"""Zero-touch provisioning for the recall index.
+
+Two runtime dependencies:
+
+* **sqlite-vec extension** — ships inside the ``sqlite-vec`` pip wheel (a base
+  dependency) which bundles the platform-specific ``vec0`` binary, so there is
+  nothing to download; we only resolve its path and verify the interpreter can
+  load extensions at all (the macOS *system* Python 3.9 cannot — the project's
+  3.11+ interpreters can).
+* **EmbeddingGemma q4 ONNX model** — downloaded once from the ungated
+  ``onnx-community`` mirror, mirroring ``agent/tools/ripgrep.py``: a module-level
+  asyncio lock, double-checked, staged on the same filesystem then atomically
+  moved, verified before a ``.ready`` marker is written, and never raising
+  (returns ``None`` so the caller disables recall gracefully).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import httpx
+from loguru import logger
+
+from ragnarbot.agent.index import (
+    DOC_PREFIX,
+    EMBED_DIM,
+    MODEL_REPO,
+    ONNX_DATA_SUFFIX,
+    QUANT_FILES,
+    TOKENIZER_FILES,
+)
+
+DEFAULT_REV = "5090578d9565bb06545b4552f76e6bc2c93e4a66"
+_HF_URL = "https://huggingface.co/{repo}/resolve/{rev}/{file}"
+_model_lock = asyncio.Lock()
+
+
+# ── sqlite-vec ──────────────────────────────────────────────────────
+
+def sqlite_vec_supported() -> bool:
+    """Return True if this interpreter's sqlite3 can load extensions.
+
+    sqlite-vec is loaded as a runtime extension, which requires
+    ``Connection.enable_load_extension`` — present on the project's uv/Homebrew
+    CPython 3.11+, absent on the macOS system Python. Never raises.
+    """
+    con = None
+    try:
+        con = sqlite3.connect(":memory:")
+        if not hasattr(con, "enable_load_extension"):
+            return False
+        con.enable_load_extension(True)
+        return True
+    except Exception:
+        return False
+    finally:
+        if con is not None:
+            con.close()
+
+
+def ensure_sqlite_vec() -> str | None:
+    """Resolve the bundled sqlite-vec loadable extension path, or None."""
+    try:
+        import sqlite_vec
+    except Exception as exc:  # pragma: no cover - packaging error
+        logger.warning("sqlite-vec not importable ({}); recall disabled", exc)
+        return None
+    try:
+        return sqlite_vec.loadable_path()
+    except Exception as exc:  # pragma: no cover - missing platform binary
+        logger.warning("sqlite-vec loadable_path unavailable ({}); recall disabled", exc)
+        return None
+
+
+# ── embedding model ─────────────────────────────────────────────────
+
+def model_dir(models_root: Path, quant: str, rev: str) -> Path:
+    """Versioned cache dir for a (quant, rev) model build."""
+    return Path(models_root) / "embeddinggemma-300m" / f"{quant}-{rev[:12]}"
+
+
+def _remote_files(quant: str) -> list[str]:
+    if quant not in QUANT_FILES:
+        raise ValueError(f"unknown quant {quant!r}")
+    onnx = QUANT_FILES[quant]
+    return [onnx, onnx + ONNX_DATA_SUFFIX, *TOKENIZER_FILES]
+
+
+def onnx_path(dest: Path, quant: str) -> Path:
+    """Path to the model .onnx file inside a provisioned model dir."""
+    return dest / Path(QUANT_FILES[quant]).name
+
+
+async def ensure_embedding_model(
+    models_root: Path,
+    quant: str = "q4",
+    rev: str = DEFAULT_REV,
+    *,
+    allow_download: bool = True,
+) -> Path | None:
+    """Return a ready model dir (downloading once if needed), or None.
+
+    The dir contains ``model_<quant>.onnx`` (+ its ``.onnx_data`` sidecar) and
+    ``tokenizer.json`` / ``config.json``. Never raises.
+    """
+    dest = model_dir(models_root, quant, rev)
+    marker = dest / ".ready"
+    if marker.exists():
+        return dest
+    if not allow_download:
+        return None
+
+    async with _model_lock:
+        if marker.exists():  # another task finished while we waited
+            return dest
+        try:
+            await _download_model(quant, rev, dest)
+            ok = await asyncio.to_thread(_verify_model, dest, quant)
+            if not ok:
+                shutil.rmtree(dest, ignore_errors=True)
+                return None
+            marker.write_text(rev)
+            logger.info("EmbeddingGemma {} model ready at {}", quant, dest)
+            return dest
+        except Exception as exc:
+            logger.warning("embedding model provisioning failed ({}); recall disabled", exc)
+            shutil.rmtree(dest, ignore_errors=True)
+            return None
+
+
+async def _download_model(quant: str, rev: str, dest: Path) -> None:
+    """Download the model files into ``dest`` atomically (staged sibling dir)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+
+    staging = Path(tempfile.mkdtemp(dir=str(dest.parent), prefix=dest.name + ".incomplete-"))
+    try:
+        logger.info("Downloading EmbeddingGemma {} model (first-time setup)...", quant)
+        async with httpx.AsyncClient(follow_redirects=True, timeout=300.0) as client:
+            for remote in _remote_files(quant):
+                url = _HF_URL.format(repo=MODEL_REPO, rev=rev, file=remote)
+                out = staging / Path(remote).name
+                async with client.stream("GET", url) as resp:
+                    resp.raise_for_status()
+                    with out.open("wb") as fh:
+                        async for chunk in resp.aiter_bytes(1 << 20):
+                            fh.write(chunk)
+        os.replace(staging, dest)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def _verify_model(dest: Path, quant: str) -> bool:
+    """Load the ONNX in ORT and run a 1-token inference before trusting the cache.
+
+    Confirms the export has the pooled ``sentence_embedding`` output at the
+    expected dimension — a renamed/empty/wrong asset cannot poison the cache.
+    """
+    import numpy as np
+    import onnxruntime as ort
+    from tokenizers import Tokenizer
+
+    path = onnx_path(dest, quant)
+    tok = Tokenizer.from_file(str(dest / "tokenizer.json"))
+    sess = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+
+    out_names = [o.name for o in sess.get_outputs()]
+    if "sentence_embedding" not in out_names:
+        logger.warning("ONNX export lacks 'sentence_embedding' output; unusable")
+        return False
+
+    in_names = [i.name for i in sess.get_inputs()]
+    enc = tok.encode(DOC_PREFIX + "test")
+    ids = np.array([enc.ids], dtype=np.int64)
+    mask = np.array([[1] * len(enc.ids)], dtype=np.int64)
+    feed: dict = {}
+    if "input_ids" in in_names:
+        feed["input_ids"] = ids
+    if "attention_mask" in in_names:
+        feed["attention_mask"] = mask
+    if "token_type_ids" in in_names:
+        feed["token_type_ids"] = np.zeros_like(ids)
+    if "position_ids" in in_names:
+        feed["position_ids"] = np.clip(np.cumsum(mask, axis=1) - 1, 0, None).astype(np.int64)
+
+    outs = sess.run(["sentence_embedding"], feed)
+    dim = int(np.asarray(outs[0]).shape[-1])
+    if dim != EMBED_DIM:
+        logger.warning("ONNX sentence_embedding dim {} != expected {}", dim, EMBED_DIM)
+        return False
+    return True

--- a/ragnarbot/agent/index/render.py
+++ b/ragnarbot/agent/index/render.py
@@ -1,0 +1,36 @@
+"""Render recall hits into a compact, located, dated payload for the LLM."""
+
+from __future__ import annotations
+
+
+def _when(ts: str | None) -> str:
+    return ts[:16].replace("T", " ") if ts else ""
+
+
+def _meta_line(r: dict) -> str:
+    if r.get("corpus") == "chat":
+        span = _when(r.get("ts_start"))
+        end = _when(r.get("ts_end"))
+        when = span if (not end or end == span) else f"{span} … {end}"
+        dlg = r.get("dialogue_id") or r.get("source_id") or "?"
+        return f"chat · {dlg} · {when}"
+    scope = r.get("scope_kind") or "memory"
+    day = r.get("day_start") or "long-term"
+    hp = r.get("heading_path")
+    tail = f" · {hp}" if hp else ""
+    return f"memory · {scope} · {day}{tail}"
+
+
+def render_results(rows: list[dict], max_chars: int = 20000) -> str:
+    """Numbered, metadata-headed result blocks; truncated to a char budget."""
+    if not rows:
+        return "No matches."
+    blocks = []
+    for i, r in enumerate(rows, 1):
+        path = r.get("source_path") or ""
+        loc = f"  ↳ {path}" if path else ""
+        blocks.append(f"[{i}] {_meta_line(r)}{loc}\n{(r.get('body') or '').strip()}")
+    text = "\n\n".join(blocks)
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + "\n… (results truncated)"
+    return text

--- a/ragnarbot/agent/index/store.py
+++ b/ragnarbot/agent/index/store.py
@@ -1,0 +1,318 @@
+"""SQLite-backed hybrid store: sqlite-vec (dense KNN) + FTS5 (BM25), fused by RRF.
+
+All DB work runs on ONE dedicated thread that owns the single connection (SQLite
+allows one writer; sqlite-vec extensions are per-connection). Callers await async
+methods that marshal onto that thread, so the event loop never blocks on SQLite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import sqlite_vec
+from loguru import logger
+
+from ragnarbot.agent.index import EMBED_DIM
+
+# Persisted columns of `chunks` (excluding the autoincrement id).
+_COLS = [
+    "corpus", "source_id", "chunk_hash", "body", "source_path", "scope_kind",
+    "dialogue_id", "user_key", "day_start", "day_end", "ts_start", "ts_end",
+    "heading_path", "chunk_index", "used_tools", "msg_start", "msg_end",
+]
+
+_DDL = f"""
+CREATE TABLE IF NOT EXISTS chunks (
+    id INTEGER PRIMARY KEY,
+    corpus TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    chunk_hash TEXT NOT NULL,
+    body TEXT NOT NULL,
+    source_path TEXT,
+    scope_kind TEXT,
+    dialogue_id TEXT,
+    user_key TEXT,
+    day_start TEXT,
+    day_end TEXT,
+    ts_start TEXT,
+    ts_end TEXT,
+    heading_path TEXT,
+    chunk_index INTEGER,
+    used_tools TEXT,
+    msg_start INTEGER,
+    msg_end INTEGER,
+    UNIQUE(corpus, source_id, chunk_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_src ON chunks(corpus, source_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[{EMBED_DIM}]);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(
+    body, content='chunks', content_rowid='id',
+    tokenize='unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+    INSERT INTO fts_chunks(rowid, body) VALUES (new.id, new.body);
+END;
+CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+    INSERT INTO fts_chunks(fts_chunks, rowid, body) VALUES ('delete', old.id, old.body);
+END;
+
+CREATE TABLE IF NOT EXISTS index_state (
+    key TEXT PRIMARY KEY,
+    content_hash TEXT,
+    model_key TEXT,
+    indexed_upto INTEGER DEFAULT 0,
+    updated_at TEXT
+);
+"""
+
+
+def _scope_to_corpora(scope: str) -> set[str]:
+    """Map a tool-facing scope to stored corpus values."""
+    if scope == "both":
+        return {"memory", "chat"}
+    if scope == "chats":
+        return {"chat"}
+    if scope == "memory":
+        return {"memory"}
+    return {scope}  # tolerate exact corpus names too
+
+
+def _fts_query(text: str) -> str | None:
+    """Build a safe FTS5 MATCH query (OR of quoted unicode word terms)."""
+    terms = [t for t in re.findall(r"\w+", text, flags=re.UNICODE) if len(t) > 1][:32]
+    if not terms:
+        return None
+    return " OR ".join('"%s"' % t.replace('"', '""') for t in terms)
+
+
+class Store:
+    """Async facade over a single-writer sqlite-vec + FTS5 database."""
+
+    def __init__(self, db_path: Path):
+        self._db_path = Path(db_path)
+        self._pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="recall-db")
+        self._conn: sqlite3.Connection | None = None
+
+    async def _call(self, fn, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._pool, fn, *args)
+
+    # ── lifecycle ───────────────────────────────────────────────────
+    async def open(self) -> None:
+        await self._call(self._open)
+
+    def _open(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._db_path))
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.executescript(_DDL)
+        conn.commit()
+        self._conn = conn
+
+    async def close(self) -> None:
+        await self._call(self._close)
+        self._pool.shutdown(wait=True)
+
+    def _close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    async def self_test(self) -> bool:
+        return await self._call(self._self_test)
+
+    def _self_test(self) -> bool:
+        try:
+            (v,) = self._conn.execute("select vec_version()").fetchone()
+            self._conn.execute("select count(*) from chunks").fetchone()
+            return bool(v)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("recall store self-test failed: {}", exc)
+            return False
+
+    # ── writes ──────────────────────────────────────────────────────
+    async def upsert(self, rows: list[dict[str, Any]]) -> int:
+        return await self._call(self._upsert, rows)
+
+    def _upsert(self, rows: list[dict[str, Any]]) -> int:
+        conn = self._conn
+        placeholders = ", ".join(["?"] * len(_COLS))
+        sql = f"INSERT OR IGNORE INTO chunks ({', '.join(_COLS)}) VALUES ({placeholders})"
+        inserted = 0
+        for row in rows:
+            values = [row.get(c) for c in _COLS]
+            cur = conn.execute(sql, values)
+            if cur.rowcount == 1:  # newly inserted (not a UNIQUE no-op)
+                emb = np.asarray(row["embedding"], dtype=np.float32).ravel()
+                conn.execute(
+                    "INSERT INTO vec_chunks(rowid, embedding) VALUES (?, ?)",
+                    (cur.lastrowid, sqlite_vec.serialize_float32(emb.tolist())),
+                )
+                inserted += 1
+        conn.commit()
+        return inserted
+
+    async def delete_source(self, corpus: str, source_id: str) -> int:
+        return await self._call(self._delete_source, corpus, source_id)
+
+    def _delete_source(self, corpus: str, source_id: str) -> int:
+        conn = self._conn
+        ids = [r[0] for r in conn.execute(
+            "SELECT id FROM chunks WHERE corpus=? AND source_id=?", (corpus, source_id)
+        )]
+        if ids:
+            conn.executemany("DELETE FROM vec_chunks WHERE rowid=?", [(i,) for i in ids])
+            conn.execute(
+                "DELETE FROM chunks WHERE corpus=? AND source_id=?", (corpus, source_id)
+            )
+            conn.commit()
+        return len(ids)
+
+    async def replace_source(self, corpus: str, source_id: str, rows: list[dict]) -> int:
+        return await self._call(self._replace_source, corpus, source_id, rows)
+
+    def _replace_source(self, corpus: str, source_id: str, rows: list[dict]) -> int:
+        self._delete_source(corpus, source_id)
+        return self._upsert(rows)
+
+    # ── index_state (manifest / cursor) ─────────────────────────────
+    async def get_state(self, key: str) -> dict | None:
+        return await self._call(self._get_state, key)
+
+    def _get_state(self, key: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT content_hash, model_key, indexed_upto FROM index_state WHERE key=?", (key,)
+        ).fetchone()
+        if not row:
+            return None
+        return {"content_hash": row[0], "model_key": row[1], "indexed_upto": row[2]}
+
+    async def set_state(self, key: str, *, content_hash=None, model_key=None, indexed_upto=None):
+        return await self._call(self._set_state, key, content_hash, model_key, indexed_upto)
+
+    def _set_state(self, key, content_hash, model_key, indexed_upto):
+        self._conn.execute(
+            """INSERT INTO index_state(key, content_hash, model_key, indexed_upto, updated_at)
+               VALUES (?,?,?,?,?)
+               ON CONFLICT(key) DO UPDATE SET
+                 content_hash=coalesce(excluded.content_hash, index_state.content_hash),
+                 model_key=coalesce(excluded.model_key, index_state.model_key),
+                 indexed_upto=coalesce(excluded.indexed_upto, index_state.indexed_upto),
+                 updated_at=excluded.updated_at""",
+            (key, content_hash, model_key, indexed_upto, datetime.now().isoformat()),
+        )
+        self._conn.commit()
+
+    # ── hybrid search ───────────────────────────────────────────────
+    async def hybrid_search(
+        self,
+        query_vec: np.ndarray,
+        query_text: str,
+        *,
+        scope: str = "both",
+        top_k: int = 8,
+        rrf_k: int = 60,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        dialogue_id: str | None = None,
+    ) -> list[dict]:
+        return await self._call(
+            self._hybrid_search, query_vec, query_text, scope, top_k, rrf_k,
+            date_from, date_to, dialogue_id,
+        )
+
+    def _hybrid_search(self, query_vec, query_text, scope, top_k, rrf_k,
+                       date_from, date_to, dialogue_id) -> list[dict]:
+        conn = self._conn
+        corpora = _scope_to_corpora(scope)
+        k = max(top_k * 8, 50)
+
+        qbytes = sqlite_vec.serialize_float32(
+            np.asarray(query_vec, dtype=np.float32).ravel().tolist()
+        )
+        knn = conn.execute(
+            "SELECT rowid, distance FROM vec_chunks WHERE embedding MATCH ? AND k = ? "
+            "ORDER BY distance",
+            (qbytes, k),
+        ).fetchall()
+        knn_ids = [r[0] for r in knn]
+
+        bm_ids: list[int] = []
+        match = _fts_query(query_text)
+        if match:
+            bm = conn.execute(
+                "SELECT rowid, bm25(fts_chunks) AS s FROM fts_chunks "
+                "WHERE fts_chunks MATCH ? ORDER BY s LIMIT ?",
+                (match, k),
+            ).fetchall()
+            bm_ids = [r[0] for r in bm]
+
+        cand = list(dict.fromkeys(knn_ids + bm_ids))
+        if not cand:
+            return []
+
+        allowed = self._filter_candidates(cand, corpora, date_from, date_to, dialogue_id)
+        if not allowed:
+            return []
+
+        scores: dict[int, float] = {}
+        for ranked in (knn_ids, bm_ids):
+            rank = 0
+            for cid in ranked:
+                if cid not in allowed:
+                    continue
+                rank += 1
+                scores[cid] = scores.get(cid, 0.0) + 1.0 / (rrf_k + rank)
+
+        top = sorted(scores, key=lambda c: scores[c], reverse=True)[:top_k]
+        return self._fetch_rows(top, scores)
+
+    def _filter_candidates(self, ids, corpora, date_from, date_to, dialogue_id) -> set[int]:
+        qs = ",".join("?" * len(ids))
+        rows = self._conn.execute(
+            f"SELECT id, corpus, day_start, day_end, dialogue_id FROM chunks WHERE id IN ({qs})",
+            ids,
+        ).fetchall()
+        allowed: set[int] = set()
+        for cid, corpus, day_start, day_end, dlg in rows:
+            if corpus not in corpora:
+                continue
+            if dialogue_id and dlg != dialogue_id:
+                continue
+            if date_from and (day_end or "9999") < date_from:
+                continue
+            if date_to and (day_start or "0000") > date_to:
+                continue
+            allowed.add(cid)
+        return allowed
+
+    def _fetch_rows(self, ids: list[int], scores: dict[int, float]) -> list[dict]:
+        if not ids:
+            return []
+        qs = ",".join("?" * len(ids))
+        cur = self._conn.execute(
+            f"SELECT id, {', '.join(_COLS)} FROM chunks WHERE id IN ({qs})", ids
+        )
+        names = [d[0] for d in cur.description]
+        by_id = {r[0]: dict(zip(names, r)) for r in cur.fetchall()}
+        out = []
+        for cid in ids:  # preserve RRF order
+            row = by_id.get(cid)
+            if row:
+                row["score"] = round(scores.get(cid, 0.0), 6)
+                out.append(row)
+        return out

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -349,6 +349,9 @@ class AgentLoop:
         """Run the agent loop, processing messages from the bus."""
         self._running = True
         await self.memory_flush.resume_pending_jobs()
+        # Recall index: provision + backfill existing chats/memory in the background
+        # so startup is never blocked by the model download or initial indexing.
+        asyncio.create_task(self.index.resume_and_backfill())
         logger.info("Agent loop started")
 
         while self._running:

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
         BrowserConfig,
         ExecToolConfig,
         FallbackConfig,
+        RecallToolConfig,
         SearchToolConfig,
     )
     from ragnarbot.cron.service import CronService
@@ -163,8 +164,9 @@ class AgentLoop:
         steering_enabled: bool = True,
         experimental_soul: bool = False,
         browser_config: "BrowserConfig | None" = None,
+        recall_config: "RecallToolConfig | None" = None,
     ):
-        from ragnarbot.config.schema import ExecToolConfig, SearchToolConfig
+        from ragnarbot.config.schema import ExecToolConfig, RecallToolConfig, SearchToolConfig
         self.bus = bus
         self.provider = provider
         self.workspace = workspace
@@ -173,6 +175,7 @@ class AgentLoop:
         self.search_engine = search_engine
         self.exec_config = exec_config or ExecToolConfig()
         self.search_config = search_config or SearchToolConfig()
+        self.recall_config = recall_config or RecallToolConfig()
         self.cron_service = cron_service
         self.hook_service = hook_service
         self.stream_steps = stream_steps
@@ -209,11 +212,19 @@ class AgentLoop:
         self.context.experimental_soul = self.experimental_soul
         self.sessions = SessionManager(workspace)
         self._session_locks: dict[str, asyncio.Lock] = {}
+        from ragnarbot.agent.index.manager import IndexManager
+        self.index = IndexManager(
+            sessions=self.sessions,
+            config=self.recall_config,
+            save_session_fn=self._save_session_locked,
+            workspace=workspace,
+        )
         self.memory_flush = MemoryFlushManager(
             workspace=workspace,
             sessions=self.sessions,
             chat_fn=self._chat_with_fallback,
             save_session_fn=self._save_session_locked,
+            on_memory_written=self.index.on_memory_written,
         )
         self.tools = ToolRegistry()
 
@@ -255,9 +266,15 @@ class AgentLoop:
         """Register the default set of tools."""
         # File tools
         self.tools.register(ReadFileTool(model=self.model, workspace=self.workspace))
-        self.tools.register(WriteFileTool(workspace=self.workspace))
-        self.tools.register(EditFileTool(workspace=self.workspace))
+        self.tools.register(WriteFileTool(
+            workspace=self.workspace, on_write=self.index.on_memory_written))
+        self.tools.register(EditFileTool(
+            workspace=self.workspace, on_write=self.index.on_memory_written))
         self.tools.register(ListDirTool(workspace=self.workspace))
+
+        # Recall (hybrid memory + chat search)
+        from ragnarbot.agent.tools.recall import RecallTool
+        self.tools.register(RecallTool(searcher=self.index, config=self.recall_config))
 
         # Shell tool
         self.tools.register(ExecTool(
@@ -1376,6 +1393,7 @@ class AgentLoop:
                             session, memory_segment,
                         )
                         start_memory_jobs = start_memory_jobs or bool(created_jobs)
+                        self.index.enqueue_chat_segment(session, memory_segment)
                     compacted_this_turn = True
 
                 # Re-apply previous flush to history messages so the API
@@ -1590,6 +1608,7 @@ class AgentLoop:
 
         if start_memory_jobs:
             await self.memory_flush.start_session_jobs(session.key)
+        await self.index.start_chat_jobs(session)
 
         if stopped or not outbound_content:
             return None
@@ -1643,6 +1662,7 @@ class AgentLoop:
         tail_segment = self._build_new_chat_memory_segment(old_session)
         if tail_segment is not None:
             self.memory_flush.enqueue_segment(old_session, tail_segment)
+            self.index.enqueue_chat_segment(old_session, tail_segment)
             await self._save_session_locked(old_session)
 
         session = self.sessions.create_new(msg.session_key)
@@ -1658,6 +1678,7 @@ class AgentLoop:
 
         if tail_segment is not None:
             await self.memory_flush.start_session_jobs(old_session.key)
+            await self.index.start_chat_jobs(old_session)
 
         return OutboundMessage(
             channel=msg.channel,
@@ -2248,11 +2269,13 @@ class AgentLoop:
 
         if memory_segment is not None:
             self.memory_flush.enqueue_segment(session, memory_segment)
+            self.index.enqueue_chat_segment(session, memory_segment)
 
         await self._save_session_locked(session)
 
         if memory_segment is not None:
             await self.memory_flush.start_session_jobs(session.key)
+            await self.index.start_chat_jobs(session)
 
         if compactions_after > compactions_before:
             logger.info(f"Manual compaction completed for {session_key}")
@@ -2389,6 +2412,7 @@ class AgentLoop:
                             session, memory_segment,
                         )
                         start_memory_jobs = start_memory_jobs or bool(created_jobs)
+                        self.index.enqueue_chat_segment(session, memory_segment)
                     compacted_this_turn = True
 
                 # Re-apply previous flush to history messages
@@ -2582,6 +2606,7 @@ class AgentLoop:
 
         if start_memory_jobs:
             await self.memory_flush.start_session_jobs(session.key)
+        await self.index.start_chat_jobs(session)
 
         if stopped or not outbound_content:
             return None

--- a/ragnarbot/agent/memory_flush.py
+++ b/ragnarbot/agent/memory_flush.py
@@ -52,12 +52,14 @@ class MemoryFlushManager:
         sessions: SessionManager,
         chat_fn: MemoryChatFn,
         save_session_fn: Callable[[Session], Any],
+        on_memory_written: Callable[[str, str | None], Any] | None = None,
     ):
         self.workspace = workspace
         self.sessions = sessions
         self.memory = MemoryStore(workspace)
         self._chat_fn = chat_fn
         self._save_session_fn = save_session_fn
+        self._on_memory_written = on_memory_written
         self._tasks: dict[str, asyncio.Task] = {}
         self._file_locks: dict[str, asyncio.Lock] = {}
 
@@ -289,6 +291,7 @@ class MemoryFlushManager:
                 self._write_target(job, content)
 
             await self._mark_job_done(session_id, job_id, result="updated")
+            self._notify_written(job)
             logger.info(
                 f"Memory flush job {job_id} completed for {target_path or 'unknown target'}"
             )
@@ -297,6 +300,15 @@ class MemoryFlushManager:
             attempts = await self._mark_job_error(session_id, job_id, str(exc))
             if attempts is not None and attempts < self.MAX_RETRIES:
                 asyncio.create_task(self._retry_later(session_id, job_id, attempts))
+
+    def _notify_written(self, job: dict[str, Any]) -> None:
+        """Out-of-band, never-raise hook after a successful memory write."""
+        if self._on_memory_written is None:
+            return
+        try:
+            self._on_memory_written(job.get("scope"), job.get("date"))
+        except Exception as exc:
+            logger.warning(f"on_memory_written hook failed: {exc}")
 
     def _extract_content(
         self,

--- a/ragnarbot/agent/tools/config_tool.py
+++ b/ragnarbot/agent/tools/config_tool.py
@@ -398,6 +398,17 @@ class ConfigTool(Tool):
                 agent._fallback_config.recovery_probe_interval = int(value)
             return "Fallback recovery probe interval updated."
 
+        # Recall config — hot fields update the live object shared by tool + manager.
+        if path.startswith("tools.recall.") and path.split(".")[-1] in (
+            "top_k", "scope_default", "rrf_k", "max_output_chars"
+        ):
+            field = path.split(".")[-1]
+            cfg = getattr(agent, "recall_config", None)
+            if cfg is not None and hasattr(cfg, field):
+                cur = getattr(cfg, field)
+                setattr(cfg, field, int(value) if isinstance(cur, int) and not isinstance(cur, bool) else value)
+            return f"Recall {field} updated."
+
         return None
 
     def _apply_warm_reload(self, path: str, value: Any) -> str | None:

--- a/ragnarbot/agent/tools/filesystem.py
+++ b/ragnarbot/agent/tools/filesystem.py
@@ -27,6 +27,38 @@ def _resolve_path(path: str, workspace: Path | None = None) -> Path:
     return resolve_path_in_workspace(path, workspace)
 
 
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _memory_target(file_path: Path, workspace: Path | None) -> tuple[str, str | None] | None:
+    """If file_path is a memory file under workspace/memory/, return (scope, date)."""
+    if workspace is None:
+        return None
+    try:
+        rel = file_path.resolve().relative_to((Path(workspace) / "memory").resolve())
+    except (ValueError, OSError):
+        return None
+    if len(rel.parts) != 1:
+        return None
+    if file_path.name == "MEMORY.md":
+        return ("long_term", None)
+    if file_path.suffix == ".md" and _DATE_RE.match(file_path.stem):
+        return ("daily", file_path.stem)
+    return None
+
+
+def _fire_memory_hook(on_write, file_path: Path, workspace: Path | None) -> None:
+    if on_write is None:
+        return
+    target = _memory_target(file_path, workspace)
+    if target is None:
+        return
+    try:
+        on_write(target[0], target[1])
+    except Exception:
+        pass  # never let a recall hook break a file write
+
+
 class ReadFileTool(Tool):
     """Tool to read file contents."""
 
@@ -210,8 +242,9 @@ class ReadFileTool(Tool):
 class WriteFileTool(Tool):
     """Tool to write content to a file."""
 
-    def __init__(self, workspace: Path | None = None):
+    def __init__(self, workspace: Path | None = None, on_write=None):
         self._workspace = workspace
+        self._on_write = on_write
 
     @property
     def name(self) -> str:
@@ -243,6 +276,7 @@ class WriteFileTool(Tool):
             file_path = _resolve_path(path, self._workspace)
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(content, encoding="utf-8")
+            _fire_memory_hook(self._on_write, file_path, self._workspace)
             return f"Successfully wrote {len(content)} bytes to {path}"
         except PermissionError:
             return f"Error: Permission denied: {path}"
@@ -253,8 +287,9 @@ class WriteFileTool(Tool):
 class EditFileTool(Tool):
     """Tool to edit a file by replacing text."""
 
-    def __init__(self, workspace: Path | None = None):
+    def __init__(self, workspace: Path | None = None, on_write=None):
         self._workspace = workspace
+        self._on_write = on_write
 
     @property
     def name(self) -> str:
@@ -345,6 +380,7 @@ class EditFileTool(Tool):
 
             with file_path.open("w", encoding="utf-8", newline="") as fh:
                 fh.write(new_content)
+            _fire_memory_hook(self._on_write, file_path, self._workspace)
             return self._success(path, content, new_content, mode, n)
         except PermissionError:
             return f"Error: Permission denied: {path}"

--- a/ragnarbot/agent/tools/recall.py
+++ b/ragnarbot/agent/tools/recall.py
@@ -18,11 +18,14 @@ class RecallTool(Tool):
 
     name = "recall"
     description = (
-        "Search your own long-term memory notes and your past chat history "
-        "(hybrid semantic + keyword). Use it when the user refers to something "
-        "discussed earlier, asks what you remember, or you need context from "
-        "previous days or conversations that is not in the current window. "
-        "Returns dated, located snippets (which day, which dialogue, which file)."
+        "Hybrid (semantic + keyword) search over your OWN long-term memory notes and "
+        "past chat history — not world knowledge. Reach for it when the user refers to "
+        "something discussed earlier, asks what you remember, or you need a "
+        "fact/preference/decision from previous days or sessions that isn't in the "
+        "current window. For best hits, pair a distinctive literal term (name, number, "
+        "rare word) with the concept, in the language it was likely discussed in. "
+        "Returns dated, located snippets (which day, which dialogue, which file) you "
+        "can file_read to expand."
     )
     parameters = {
         "type": "object",

--- a/ragnarbot/agent/tools/recall.py
+++ b/ragnarbot/agent/tools/recall.py
@@ -1,0 +1,78 @@
+"""recall: hybrid (vector + BM25) search over the agent's memory files and chats."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ragnarbot.agent.index.render import render_results
+from ragnarbot.agent.tools.base import Tool
+
+
+class RecallTool(Tool):
+    """Search long-term memory and past chats. Backed by an IndexManager-like searcher.
+
+    The searcher must provide: ``available() -> bool``, ``status() -> str`` (shown when
+    not yet available), and ``async search(query, *, scope, top_k, date_from, date_to,
+    dialogue_id) -> list[dict]``.
+    """
+
+    name = "recall"
+    description = (
+        "Search your own long-term memory notes and your past chat history "
+        "(hybrid semantic + keyword). Use it when the user refers to something "
+        "discussed earlier, asks what you remember, or you need context from "
+        "previous days or conversations that is not in the current window. "
+        "Returns dated, located snippets (which day, which dialogue, which file)."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to look for (natural language)."},
+            "scope": {
+                "type": "string",
+                "enum": ["memory", "chats", "both"],
+                "description": "Where to search. Default: both.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default from config).",
+                "minimum": 1,
+                "maximum": 50,
+            },
+            "date_from": {"type": "string", "description": "Earliest day, YYYY-MM-DD (optional)."},
+            "date_to": {"type": "string", "description": "Latest day, YYYY-MM-DD (optional)."},
+            "dialogue_id": {"type": "string", "description": "Restrict to one dialogue/session id (optional)."},
+        },
+        "required": ["query"],
+    }
+
+    def __init__(self, searcher: Any, config: Any):
+        self._searcher = searcher
+        self._cfg = config
+
+    async def execute(
+        self,
+        query: str,
+        scope: str | None = None,
+        limit: int | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        dialogue_id: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        if not self._searcher.available():
+            return self._searcher.status()
+        scope = scope or self._cfg.scope_default
+        top_k = limit or self._cfg.top_k
+        try:
+            rows = await self._searcher.search(
+                query,
+                scope=scope,
+                top_k=top_k,
+                date_from=date_from,
+                date_to=date_to,
+                dialogue_id=dialogue_id,
+            )
+        except Exception as e:  # never surface a stack trace to the model
+            return f"Recall search failed: {e}"
+        return render_results(rows, self._cfg.max_output_chars)

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -49,6 +49,18 @@ Search file *contents* for a regular expression. Use to find where a symbol, str
 - `output_mode` (optional) — `content` (path:line:text, default), `files_with_matches`, or `count`.
 - `context_lines` (optional) — lines of surrounding context per match.
 
+## Memory & Recall
+
+### recall
+Hybrid (semantic vector + keyword BM25) search over **your own memory notes and past chat history**. Use it when the user refers to something discussed earlier, asks what you remember, or you need context from previous days or conversations that isn't in the current window. Indexing is automatic and runs in the background — you don't manage it.
+- `query` — what to look for, in natural language.
+- `scope` (optional) — `memory`, `chats`, or `both` (default `both`).
+- `limit` (optional) — max results.
+- `date_from` / `date_to` (optional) — restrict to a day range (`YYYY-MM-DD`).
+- `dialogue_id` (optional) — restrict to a single past session.
+
+Each hit is dated and located (which day, which dialogue/file), so you can cite it or `file_read` the source for more. If recall says it's still preparing, the index is downloading its model on first run — try again shortly.
+
 ## Background Execution
 
 For tasks that take more than a few seconds — image generation, data processing, long scripts, batch operations. Do NOT use these for quick commands; use `exec` instead.

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -52,14 +52,36 @@ Search file *contents* for a regular expression. Use to find where a symbol, str
 ## Memory & Recall
 
 ### recall
-Hybrid (semantic vector + keyword BM25) search over **your own memory notes and past chat history**. Use it when the user refers to something discussed earlier, asks what you remember, or you need context from previous days or conversations that isn't in the current window. Indexing is automatic and runs in the background — you don't manage it.
-- `query` — what to look for, in natural language.
-- `scope` (optional) — `memory`, `chats`, or `both` (default `both`).
-- `limit` (optional) — max results.
-- `date_from` / `date_to` (optional) — restrict to a day range (`YYYY-MM-DD`).
-- `dialogue_id` (optional) — restrict to a single past session.
+Hybrid search (semantic vectors + BM25 keywords, RRF-fused) over **your own** long-term memory and this user's history — your memory, **not world knowledge**. Two corpora: **memory** = your distilled notes (daily `YYYY-MM-DD` files + long-term `MEMORY.md`: facts, preferences, decisions, open threads); **chats** = raw past conversation turns (what was literally said). Every hit comes back dated and located (day · dialogue · file). Indexing is automatic and runs in the background — you don't manage it.
 
-Each hit is dated and located (which day, which dialogue/file), so you can cite it or `file_read` the source for more. If recall says it's still preparing, the index is downloading its model on first run — try again shortly.
+**Decide before you answer** — only when the turn leans on the past, run this check top to bottom:
+1. Is the answer already in the current context window? → do **not** recall.
+2. Does the user point at shared history? ("як ми домовились", "що я тобі казав про…", "той ресторан/файл", "помнишь…", "remember when…") → recall.
+3. A standing preference, a fact about the user, or a past decision you should already "know"? → recall `scope="memory"`.
+4. Need the literal wording of an earlier exchange? → recall `scope="chats"`.
+
+If any of 2–4 is yes and 1 is no, call recall **before** answering — and before saying "I don't know" or re-asking the user. One cheap lookup beats guessing.
+
+**Don't call it** for in-window content, general knowledge or reasoning you already have, a genuinely new topic with no prior history, or small talk — and don't re-query a thread you already recalled this turn. Each call embeds the query and scans the index: cheap, not free.
+
+**Write the query (exploit the hybrid):** pair **one or two distinctive literal terms** (names, numbers, error strings, rare words — these win the keyword leg) **with the concept in plain words** (wins the semantic leg). Natural language, not boolean; one focused intent per call; phrase it in the language the topic was likely discussed in (mostly uk/ru).
+- "ми вирішили на Postgres чи MySQL?" → `query:"рішення база даних Postgres MySQL", scope:"memory"`
+- "какие у меня предпочтения по кофе?" → `query:"предпочтения кофе", scope:"memory"`
+- vague→strong: `"бот"` → `"ragnarbot падає при старті, помилка session JSONL", scope:"both"`
+- vague→strong: `"мои настройки"` → `"предпочтения: отвечать кратко, без воды", scope:"memory"`
+
+**Params:**
+- `query` — natural language (see above).
+- `scope` — `memory`, `chats`, or `both` (default `both`; use when unsure).
+- `limit` — max results (1–50; default from config). Raise only if the first pass is thin.
+- `date_from` / `date_to` — `YYYY-MM-DD`; add when the user anchors in time ("минулого тижня", "in May") to cut noise.
+- `dialogue_id` — confine to one past session; use **only** an id you saw in a prior hit's metadata, never invented.
+
+**Handle results:**
+- **No matches → iterate, don't stop at one try:** drop filters → widen `scope` to `both` → rephrase with synonyms or the other language → drop a possibly-misspelled rare term. After ~2 honest attempts, tell the user you don't have it rather than inventing.
+- **Off-target → re-query** with a distinctive literal, a different scope, or a date range.
+- **Good hit → ground your answer:** cite where it came from ("у нотатках від 2026-05-12…"), and `file_read` the shown source path if the snippet is partial.
+- If recall **reports it's still preparing**, the index is downloading its embedding model on first run (not "no memory") — answer from context if you can, retry shortly.
 
 ## Background Execution
 

--- a/ragnarbot/cli/commands.py
+++ b/ragnarbot/cli/commands.py
@@ -355,6 +355,7 @@ def gateway_main(
                 model, auth_method, creds,
             ),
             browser_config=config.tools.browser,
+            recall_config=config.tools.recall,
         )
 
         def _format_schedule(schedule) -> str:

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -224,12 +224,54 @@ class BrowserConfig(BaseModel):
     )
 
 
+class RecallToolConfig(BaseModel):
+    """Hybrid (vector + BM25) recall search over memory files and chats."""
+    enabled: bool = Field(
+        default=True,
+        json_schema_extra={"reload": "warm", "label": "Enable the recall search tool + background indexing"},
+    )
+    auto_install: bool = Field(
+        default=True,
+        json_schema_extra={"reload": "warm", "label": "Auto-download the embedding model and sqlite-vec extension"},
+    )
+    quant: str = Field(
+        default="q4",
+        pattern="^(q4|q8|fp16|fp32)$",
+        json_schema_extra={"reload": "warm", "label": "EmbeddingGemma quant (q4|q8|fp16|fp32)"},
+    )
+    embed_rev: str = Field(
+        default="5090578d9565bb06545b4552f76e6bc2c93e4a66",
+        json_schema_extra={"reload": "warm", "label": "Pinned onnx-community model revision (commit sha)"},
+    )
+    top_k: int = Field(
+        default=8,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Default number of recall results"},
+    )
+    scope_default: str = Field(
+        default="both",
+        pattern="^(memory|chats|both)$",
+        json_schema_extra={"reload": "hot", "label": "Default recall scope (memory|chats|both)"},
+    )
+    rrf_k: int = Field(
+        default=60,
+        ge=1,
+        json_schema_extra={"reload": "hot", "label": "Reciprocal Rank Fusion constant k"},
+    )
+    max_output_chars: int = Field(
+        default=20000,
+        ge=1000,
+        json_schema_extra={"reload": "hot", "label": "Max characters in a recall result payload"},
+    )
+
+
 class ToolsConfig(BaseModel):
     """Tools configuration."""
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     search: SearchToolConfig = Field(default_factory=SearchToolConfig)
     browser: BrowserConfig = Field(default_factory=BrowserConfig)
+    recall: RecallToolConfig = Field(default_factory=RecallToolConfig)
 
 
 class TranscriptionConfig(BaseModel):

--- a/ragnarbot/instance.py
+++ b/ragnarbot/instance.py
@@ -46,6 +46,8 @@ class InstanceInfo:
     runtime_state_path: Path
     pending_update_path: Path
     metadata_path: Path
+    index_dir: Path
+    models_dir: Path
 
 
 class GatewayClaimError(RuntimeError):
@@ -154,6 +156,8 @@ def get_instance(profile: str | None = None) -> InstanceInfo:
         runtime_state_path=data_root / "runtime_state.json",
         pending_update_path=data_root / "pending_update.json",
         metadata_path=data_root / "instance.json",
+        index_dir=data_root / "index",
+        models_dir=data_root / "models",
     )
 
 

--- a/ragnarbot/utils/helpers.py
+++ b/ragnarbot/utils/helpers.py
@@ -51,6 +51,16 @@ def get_memory_path(workspace: Path | None = None) -> Path:
     return ensure_dir(ws / "memory")
 
 
+def get_index_dir() -> Path:
+    """Get the recall index storage directory (per profile)."""
+    return ensure_dir(get_instance().index_dir)
+
+
+def get_models_dir() -> Path:
+    """Get the downloaded-models storage directory (per profile)."""
+    return ensure_dir(get_instance().models_dir)
+
+
 def get_skills_path(workspace: Path | None = None) -> Path:
     """Get the skills directory within the workspace."""
     ws = workspace or get_workspace_path()

--- a/tests/test_recall_chat_chunking.py
+++ b/tests/test_recall_chat_chunking.py
@@ -1,0 +1,154 @@
+"""Chat normalization + Q->A chunking, with a deterministic fake tokenizer."""
+
+import pytest
+
+from ragnarbot.agent.index import MAX_TOKENS, MAX_TURNS, chunking
+from ragnarbot.agent.index import chat_chunking as cc
+
+
+class _Enc:
+    def __init__(self, ids):
+        self.ids = ids
+
+
+class FakeTokenizer:
+    """Whitespace-word tokenizer with reversible encode/decode (test-only)."""
+
+    def __init__(self):
+        self.w2i: dict[str, int] = {}
+        self.i2w: dict[int, str] = {}
+
+    def _id(self, w: str) -> int:
+        if w not in self.w2i:
+            i = len(self.w2i) + 10
+            self.w2i[w] = i
+            self.i2w[i] = w
+        return self.w2i[w]
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> _Enc:
+        ids = [self._id(w) for w in text.split()]
+        if add_special_tokens:
+            ids = [1, *ids, 2]
+        return _Enc(ids)
+
+    def decode(self, ids: list[int]) -> str:
+        return " ".join(self.i2w.get(i, "") for i in ids if i in self.i2w).strip()
+
+
+META = {"source_id": "telegram_42_20260628_abc", "source_path": "/c/x.jsonl",
+        "user_key": "telegram:42", "user_name": "Leo"}
+
+
+@pytest.fixture(autouse=True)
+def _tok():
+    chunking.set_tokenizer(FakeTokenizer())
+    yield
+    chunking.set_tokenizer(None)
+
+
+def _msg(role, content, ts="2026-06-28T10:00:00", **extra):
+    m = {"role": role, "content": content, "metadata": {"timestamp": ts}}
+    m.update(extra)
+    return m
+
+
+def test_normalization_filters():
+    msgs = [
+        _msg("user", "real question about vectors"),
+        _msg("assistant", "", tool_calls=[{"function": {"name": "grep"}}]),  # tool-only -> drop
+        _msg("tool", "tool output", name="grep"),                            # drop
+        _msg("assistant", "Found 3 matches in file.py",                       # substantive caption -> keep
+             tool_calls=[{"function": {"name": "grep"}}]),
+        _msg("assistant", "ok"),                                             # plain reply -> keep
+        _msg("user", "[Voice message transcription: привіт як справи]"),      # unwrap
+        _msg("user", "[Voice message — transcription failed: net]"),          # drop
+        _msg("user", "[System: background_poll tick]"),                       # telemetry -> drop
+    ]
+    turns = cc.normalize(msgs, 0, len(msgs))
+    texts = [(t.role, t.text) for t in turns]
+    assert ("user", "real question about vectors") in texts
+    assert ("assistant", "Found 3 matches in file.py") in texts  # caption kept (has digit)
+    assert ("assistant", "ok") in texts
+    assert ("user", "привіт як справи") in texts                 # tag stripped
+    assert all("transcription failed" not in t.text for t in turns)
+    assert all("background_poll" not in t.text for t in turns)
+    # used_tools recorded on the caption turn
+    cap = next(t for t in turns if t.text.startswith("Found 3"))
+    assert "grep" in cap.used_tools
+
+
+def test_nonsubstantive_caption_dropped():
+    msgs = [_msg("assistant", "ok done", tool_calls=[{"function": {"name": "click"}}])]
+    turns = cc.normalize(msgs, 0, 1)
+    assert turns == []  # short caption, no signal -> dropped
+
+
+def test_compaction_summary_becomes_summary_turn():
+    msgs = [_msg("user", "[Conversation Summary]\nUser likes vectors.")]
+    msgs[0]["metadata"]["type"] = "compaction"
+    turns = cc.normalize(msgs, 0, 1)
+    assert len(turns) == 1 and turns[0].role == "summary"
+    assert "User likes vectors." in turns[0].text
+
+
+def test_pairing_kinds():
+    turns = [
+        cc.Turn("user", "q1", "t", 0),
+        cc.Turn("assistant", "a1", "t", 1),
+        cc.Turn("user", "q2", "t", 2),       # q_only (no following assistant)
+        cc.Turn("summary", "s", "t", 3),
+    ]
+    pairs = cc.pair_turns(turns)
+    kinds = [p.kind for p in pairs]
+    assert kinds == ["qa", "q_only", "summary"]
+
+
+def test_chunk_basic_metadata_and_body():
+    msgs = [
+        _msg("user", "how does hybrid search work", ts="2026-06-28T10:00:00"),
+        _msg("assistant", "it fuses BM25 and vectors", ts="2026-06-28T10:01:00"),
+    ]
+    rows = cc.chunk_chat_segment(msgs, 0, len(msgs), META, "mk")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["corpus"] == "chat"
+    assert r["source_id"] == META["source_id"]
+    assert r["dialogue_id"] == META["source_id"]
+    assert r["day_start"] == "2026-06-28"
+    assert r["ts_start"] == "2026-06-28T10:00:00" and r["ts_end"] == "2026-06-28T10:01:00"
+    assert r["msg_start"] == 0 and r["msg_end"] == 1
+    assert "Leo:" in r["body"] and "Assistant:" in r["body"] and "[2026-06-28 10:00" in r["body"]
+
+
+def test_many_turns_respect_turn_and_token_caps():
+    msgs = []
+    for k in range(20):
+        msgs.append(_msg("user", f"question number {k} " + " ".join(f"w{k}_{j}" for j in range(50)),
+                         ts=f"2026-06-28T10:{k:02d}:00"))
+        msgs.append(_msg("assistant", f"answer number {k} " + " ".join(f"a{k}_{j}" for j in range(50)),
+                         ts=f"2026-06-28T10:{k:02d}:30"))
+    rows = cc.chunk_chat_segment(msgs, 0, len(msgs), META, "mk")
+    assert len(rows) > 1
+    from ragnarbot.agent.index import DOC_PREFIX
+    for r in rows:
+        # token cap on the real embedded artifact
+        assert chunking.count_tokens(DOC_PREFIX + r["body"], special=True) <= MAX_TOKENS
+        # turn cap: count speaker lines (exclude the header line)
+        speaker_lines = [ln for ln in r["body"].split("\n") if ln.startswith(("Leo:", "Assistant:"))]
+        assert len(speaker_lines) <= MAX_TURNS
+
+
+def test_oversized_single_turn_reflows_into_parts():
+    huge = " ".join(f"x{i}" for i in range(MAX_TOKENS + 400))
+    msgs = [_msg("user", "explain"), _msg("assistant", huge)]
+    rows = cc.chunk_chat_segment(msgs, 0, 2, META, "mk")
+    assert len(rows) >= 2  # reflowed
+    from ragnarbot.agent.index import DOC_PREFIX
+    for r in rows:
+        assert chunking.count_tokens(DOC_PREFIX + r["body"], special=True) <= MAX_TOKENS
+
+
+def test_empty_segment_returns_no_rows():
+    msgs = [_msg("tool", "x", name="grep"),
+            _msg("assistant", "", tool_calls=[{"function": {"name": "grep"}}])]
+    assert cc.chunk_chat_segment(msgs, 0, 2, META, "mk") == []

--- a/tests/test_recall_chunking.py
+++ b/tests/test_recall_chunking.py
@@ -1,0 +1,131 @@
+"""Memory chunking + token-budget invariants, with a deterministic fake tokenizer.
+
+The fake treats whitespace-separated words as tokens (encode/decode round-trips
+word count), so the <=MAX_TOKENS guarantee and packing logic are exercised without
+the model or network.
+"""
+
+import pytest
+
+from ragnarbot.agent.index import MAX_TOKENS, chunking
+
+
+class _Enc:
+    def __init__(self, ids):
+        self.ids = ids
+
+
+class FakeTokenizer:
+    def __init__(self):
+        self.w2i: dict[str, int] = {}
+        self.i2w: dict[int, str] = {}
+
+    def _id(self, w: str) -> int:
+        if w not in self.w2i:
+            i = len(self.w2i) + 10
+            self.w2i[w] = i
+            self.i2w[i] = w
+        return self.w2i[w]
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> _Enc:
+        ids = [self._id(w) for w in text.split()]
+        if add_special_tokens:
+            ids = [1, *ids, 2]
+        return _Enc(ids)
+
+    def decode(self, ids: list[int]) -> str:
+        return " ".join(self.i2w.get(i, "") for i in ids if i in self.i2w).strip()
+
+
+@pytest.fixture(autouse=True)
+def _set_tok():
+    chunking.set_tokenizer(FakeTokenizer())
+    yield
+    chunking.set_tokenizer(None)
+
+
+def _artifact_len(body, breadcrumb=None):
+    from ragnarbot.agent.index import DOC_PREFIX
+    art = DOC_PREFIX + (breadcrumb + "\n\n" if breadcrumb else "") + body
+    return chunking.count_tokens(art, special=True)
+
+
+def test_small_file_single_chunk():
+    text = "# 2026-06-28\n\nBought milk. Discussed the recall feature design."
+    rows = chunking.chunk_memory_file(
+        text, source_id="d", source_path="/m/2026-06-28.md",
+        scope_kind="daily", day="2026-06-28", model_key="mk",
+    )
+    assert len(rows) == 1
+    assert rows[0]["chunk_index"] == 0
+    assert rows[0]["day_start"] == rows[0]["day_end"] == "2026-06-28"
+    assert rows[0]["corpus"] == "memory"
+    assert _artifact_len(rows[0]["body"]) <= MAX_TOKENS
+
+
+def test_large_file_multichunk_all_within_cap():
+    sections = []
+    for s in range(4):
+        body = " ".join(f"word{s}_{i}" for i in range(400))
+        sections.append(f"## Section {s}\n\n{body}")
+    text = "# 2026-06-28\n\n" + "\n\n".join(sections)
+    rows = chunking.chunk_memory_file(
+        text, source_id="d", source_path="/m/x.md",
+        scope_kind="daily", day="2026-06-28", model_key="mk",
+    )
+    assert len(rows) > 1
+    for r in rows:
+        assert _artifact_len(r["body"], r.get("heading_path")) <= MAX_TOKENS
+    # continuation chunks carry a breadcrumb (heading_path) and indices are ordered
+    assert [r["chunk_index"] for r in rows] == list(range(len(rows)))
+
+
+def test_recursive_split_respects_limit():
+    text = " ".join(f"w{i}" for i in range(1000))
+    parts = chunking.recursive_split(text, limit=100)
+    assert len(parts) > 1
+    for p in parts:
+        assert chunking.count_tokens(p) <= 100
+
+
+def test_token_windows_never_exceeds_limit():
+    text = " ".join(f"w{i}" for i in range(250))
+    wins = chunking.token_windows(text, limit=60, overlap=10)
+    assert len(wins) > 1
+    for w in wins:
+        assert chunking.count_tokens(w) <= 60
+
+
+def test_finalize_reflows_oversized_body():
+    big = " ".join(f"w{i}" for i in range(MAX_TOKENS + 300))
+    pieces = chunking.finalize(big, breadcrumb=None)
+    assert len(pieces) > 1
+    for p in pieces:
+        assert _artifact_len(p) <= MAX_TOKENS
+
+
+def test_heading_is_sticky_and_inline():
+    text = "## Open Threads\n\nfollow up on the deploy"
+    rows = chunking.chunk_memory_file(
+        text, source_id="d", source_path="/m/x.md",
+        scope_kind="daily", day="2026-06-28", model_key="mk",
+    )
+    assert "Open Threads" in rows[0]["body"]
+    assert rows[0]["heading_path"] == "Open Threads"
+
+
+def test_long_term_has_empty_day():
+    rows = chunking.chunk_memory_file(
+        "# Long-term\n\nUser prefers concise answers.",
+        source_id="MEMORY.md", source_path="/m/MEMORY.md",
+        scope_kind="long_term", day="2026-06-28", model_key="mk",
+    )
+    assert rows[0]["day_start"] == "" and rows[0]["day_end"] == ""
+
+
+def test_chunk_hash_depends_on_model_key():
+    h1 = chunking.chunk_hash("same body", "mk1")
+    h2 = chunking.chunk_hash("same body", "mk2")
+    h3 = chunking.chunk_hash("same  body", "mk1")  # whitespace-normalized -> equal to h1
+    assert h1 != h2
+    assert h1 == h3

--- a/tests/test_recall_manager.py
+++ b/tests/test_recall_manager.py
@@ -1,0 +1,69 @@
+"""IndexManager hot-path safety + job bookkeeping (no model/network)."""
+
+from types import SimpleNamespace
+
+from ragnarbot.agent.index.manager import IndexManager
+from ragnarbot.config.schema import RecallToolConfig
+
+
+def _mgr(tmp_path, **cfg_over):
+    cfg = RecallToolConfig(**cfg_over)
+    return IndexManager(sessions=None, config=cfg, save_session_fn=None, workspace=tmp_path)
+
+
+def _session():
+    return SimpleNamespace(key="telegram_1_20260628_aaa", metadata={}, user_key="telegram:1")
+
+
+def _seg(a, b):
+    return SimpleNamespace(start_idx=a, end_idx=b)
+
+
+def test_enqueue_adds_job_and_dedups(tmp_path):
+    mgr = _mgr(tmp_path)
+    s = _session()
+    mgr.enqueue_chat_segment(s, _seg(0, 4))
+    jobs = s.metadata["vector_index"]["jobs"]
+    assert len(jobs) == 1
+    assert jobs[0]["fingerprint"] == "chat:telegram_1_20260628_aaa:0:4"
+    assert jobs[0]["status"] == "pending"
+    mgr.enqueue_chat_segment(s, _seg(0, 4))  # same range -> dedup
+    assert len(s.metadata["vector_index"]["jobs"]) == 1
+    mgr.enqueue_chat_segment(s, _seg(4, 8))  # new range -> added
+    assert len(s.metadata["vector_index"]["jobs"]) == 2
+
+
+def test_enqueue_ignores_empty_range(tmp_path):
+    mgr = _mgr(tmp_path)
+    s = _session()
+    mgr.enqueue_chat_segment(s, _seg(5, 5))
+    mgr.enqueue_chat_segment(s, _seg(9, 3))
+    assert s.metadata.get("vector_index", {}).get("jobs", []) == []
+
+
+def test_enqueue_never_raises_on_bad_session(tmp_path):
+    mgr = _mgr(tmp_path)
+    bad = SimpleNamespace(key="k")  # no metadata attribute
+    mgr.enqueue_chat_segment(bad, _seg(0, 2))  # must not raise
+
+
+def test_enqueue_disabled_is_noop(tmp_path):
+    mgr = _mgr(tmp_path, enabled=False)
+    s = _session()
+    mgr.enqueue_chat_segment(s, _seg(0, 4))
+    assert s.metadata == {}
+
+
+def test_available_and_status_before_ready(tmp_path):
+    mgr = _mgr(tmp_path)
+    assert mgr.available() is False
+    assert "preparing" in mgr.status().lower()
+    disabled = _mgr(tmp_path, enabled=False)
+    assert "disabled" in disabled.status().lower()
+
+
+def test_on_memory_written_disabled_is_noop(tmp_path):
+    mgr = _mgr(tmp_path, enabled=False)
+    # disabled -> returns before scheduling any task (no running loop needed)
+    mgr.on_memory_written("daily", "2026-06-28")
+    assert mgr._mem_tasks == set()

--- a/tests/test_recall_provision.py
+++ b/tests/test_recall_provision.py
@@ -1,0 +1,69 @@
+"""Tests for recall provisioning (sqlite-vec resolution + model cache layout).
+
+The actual model download is network-bound and validated manually; these tests
+cover the fast, deterministic pieces.
+"""
+
+from pathlib import Path
+
+from ragnarbot.agent.index import EMBED_DIM, QUANT_FILES, provision
+
+
+def test_sqlite_vec_supported_on_this_interpreter():
+    # The project requires 3.11+, whose sqlite3 supports load_extension.
+    assert provision.sqlite_vec_supported() is True
+
+
+def test_ensure_sqlite_vec_returns_existing_binary():
+    path = provision.ensure_sqlite_vec()
+    assert path is not None
+    # loadable_path returns the extension stem (no suffix); a sibling binary exists.
+    p = Path(path)
+    assert p.parent.is_dir()
+
+
+def test_sqlite_vec_actually_loads_and_queries(tmp_path):
+    import sqlite3
+
+    import sqlite_vec
+
+    con = sqlite3.connect(":memory:")
+    con.enable_load_extension(True)
+    sqlite_vec.load(con)
+    (version,) = con.execute("select vec_version()").fetchone()
+    assert isinstance(version, str) and version
+    con.close()
+
+
+def test_model_dir_is_versioned_per_quant_and_rev(tmp_path):
+    d1 = provision.model_dir(tmp_path, "q4", "abcdef123456789")
+    d2 = provision.model_dir(tmp_path, "q8", "abcdef123456789")
+    d3 = provision.model_dir(tmp_path, "q4", "fedcba987654321")
+    assert d1 != d2 and d1 != d3
+    assert "q4-abcdef123456" in d1.name
+
+
+def test_remote_files_includes_onnx_data_and_tokenizer():
+    files = provision._remote_files("q4")
+    assert QUANT_FILES["q4"] in files
+    assert QUANT_FILES["q4"] + "_data" in files
+    assert "tokenizer.json" in files
+    assert "config.json" in files
+
+
+def test_onnx_path_basename(tmp_path):
+    assert provision.onnx_path(tmp_path, "q4").name == "model_q4.onnx"
+
+
+def test_ensure_embedding_model_no_download_returns_none(tmp_path):
+    # No marker present and download disabled -> None (graceful).
+    import asyncio
+
+    result = asyncio.run(
+        provision.ensure_embedding_model(tmp_path, "q4", "deadbeef", allow_download=False)
+    )
+    assert result is None
+
+
+def test_embed_dim_constant():
+    assert EMBED_DIM == 768

--- a/tests/test_recall_store.py
+++ b/tests/test_recall_store.py
@@ -1,0 +1,127 @@
+"""Store mechanics (sqlite-vec KNN + FTS5 BM25 + RRF) with synthetic vectors.
+
+No model/network: vectors are constructed by hand so ranking is deterministic.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from ragnarbot.agent.index import EMBED_DIM
+from ragnarbot.agent.index.store import Store
+
+
+def _unit(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(EMBED_DIM).astype(np.float32)
+    return v / np.linalg.norm(v)
+
+
+def _row(corpus, source_id, body, vec, **extra):
+    base = dict(
+        corpus=corpus, source_id=source_id, chunk_hash=f"{corpus}:{source_id}:{body}",
+        body=body, embedding=vec, day_start="2026-06-28", day_end="2026-06-28",
+    )
+    base.update(extra)
+    return base
+
+
+async def _fresh_store(tmp_path) -> Store:
+    st = Store(tmp_path / "recall.db")
+    await st.open()
+    return st
+
+
+def test_open_self_test(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        assert await st.self_test() is True
+        await st.close()
+    asyncio.run(go())
+
+
+def test_upsert_dedup_and_delete(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        rows = [_row("chat", "s1", "hello world", _unit(1))]
+        assert await st.upsert(rows) == 1
+        assert await st.upsert(rows) == 0  # UNIQUE(corpus,source_id,chunk_hash) -> no-op
+        assert await st.delete_source("chat", "s1") == 1
+        assert await st.upsert(rows) == 1  # reinsert after delete
+        await st.close()
+    asyncio.run(go())
+
+
+def test_knn_ranks_nearest_vector_first(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        target = _unit(7)
+        near = (target + 0.01 * _unit(99)).astype(np.float32)
+        near /= np.linalg.norm(near)
+        await st.upsert([
+            _row("memory", "m", "alpha", target),
+            _row("memory", "m", "beta", _unit(2)),
+            _row("memory", "m", "gamma", _unit(3)),
+        ])
+        # query with a text that matches nothing (force pure vector signal)
+        res = await st.hybrid_search(near, "zzzznomatch", scope="memory", top_k=3)
+        assert res and res[0]["body"] == "alpha"
+        await st.close()
+    asyncio.run(go())
+
+
+def test_bm25_contributes_via_text(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        # all vectors random/unrelated to the query vector; only the lexical term differs
+        await st.upsert([
+            _row("chat", "s", "the quarterly revenue grew sharply", _unit(11)),
+            _row("chat", "s", "buy milk and bread", _unit(12)),
+        ])
+        res = await st.hybrid_search(_unit(500), "revenue", scope="chats", top_k=2)
+        assert res and "revenue" in res[0]["body"]
+        await st.close()
+    asyncio.run(go())
+
+
+def test_scope_and_date_filters(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        v = _unit(21)
+        await st.upsert([
+            _row("memory", "m", "vector search notes", v, day_start="2026-01-01", day_end="2026-01-01"),
+            _row("chat", "c", "vector search chat", _unit(22), day_start="2026-06-28", day_end="2026-06-28"),
+        ])
+        only_mem = await st.hybrid_search(v, "vector search", scope="memory", top_k=5)
+        assert {r["corpus"] for r in only_mem} == {"memory"}
+
+        both_recent = await st.hybrid_search(
+            v, "vector search", scope="both", top_k=5, date_from="2026-06-01", date_to="2026-06-30"
+        )
+        assert {r["corpus"] for r in both_recent} == {"chat"}  # memory row is out of date range
+        await st.close()
+    asyncio.run(go())
+
+
+def test_index_state_roundtrip(tmp_path):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        assert await st.get_state("k") is None
+        await st.set_state("k", content_hash="h1", model_key="mk", indexed_upto=5)
+        s = await st.get_state("k")
+        assert s["content_hash"] == "h1" and s["indexed_upto"] == 5
+        await st.set_state("k", indexed_upto=9)  # partial update keeps content_hash
+        s = await st.get_state("k")
+        assert s["content_hash"] == "h1" and s["indexed_upto"] == 9
+        await st.close()
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize("scope", ["memory", "chats", "both"])
+def test_empty_db_returns_empty(tmp_path, scope):
+    async def go():
+        st = await _fresh_store(tmp_path)
+        assert await st.hybrid_search(_unit(1), "anything", scope=scope, top_k=5) == []
+        await st.close()
+    asyncio.run(go())

--- a/tests/test_recall_tool.py
+++ b/tests/test_recall_tool.py
@@ -1,0 +1,98 @@
+"""RecallTool behavior + result rendering, with a fake searcher (no model/db)."""
+
+import asyncio
+from types import SimpleNamespace
+
+from ragnarbot.agent.index.render import render_results
+from ragnarbot.agent.tools.recall import RecallTool
+
+
+class FakeSearcher:
+    def __init__(self, rows, ok=True, status="preparing"):
+        self.rows = rows
+        self._ok = ok
+        self._status = status
+        self.calls = []
+
+    def available(self):
+        return self._ok
+
+    def status(self):
+        return self._status
+
+    async def search(self, query, *, scope, top_k, date_from, date_to, dialogue_id):
+        self.calls.append(dict(query=query, scope=scope, top_k=top_k,
+                               date_from=date_from, date_to=date_to, dialogue_id=dialogue_id))
+        return self.rows
+
+
+def _cfg(scope_default="both", top_k=8, max_output_chars=20000):
+    return SimpleNamespace(scope_default=scope_default, top_k=top_k,
+                           max_output_chars=max_output_chars)
+
+
+CHAT_ROW = {
+    "corpus": "chat", "dialogue_id": "telegram_42_20260628_abc",
+    "ts_start": "2026-06-28T10:00:00", "ts_end": "2026-06-28T10:05:00",
+    "source_path": "/c/x.jsonl", "body": "Leo: hi\nAssistant: hello",
+}
+MEM_ROW = {
+    "corpus": "memory", "scope_kind": "daily", "day_start": "2026-06-27",
+    "heading_path": "Open Threads", "source_path": "/m/2026-06-27.md",
+    "body": "follow up on deploy",
+}
+
+
+def test_render_includes_metadata_and_locator():
+    out = render_results([CHAT_ROW, MEM_ROW])
+    assert "[1] chat · telegram_42_20260628_abc · 2026-06-28 10:00 … 2026-06-28 10:05" in out
+    assert "/c/x.jsonl" in out
+    assert "[2] memory · daily · 2026-06-27 · Open Threads" in out
+    assert "follow up on deploy" in out
+
+
+def test_render_empty():
+    assert render_results([]) == "No matches."
+
+
+def test_render_truncates_to_budget():
+    big = [{"corpus": "memory", "scope_kind": "daily", "day_start": "2026-06-27",
+            "source_path": "/m/x.md", "body": "x" * 5000} for _ in range(10)]
+    out = render_results(big, max_chars=1000)
+    assert len(out) <= 1100 and "truncated" in out
+
+
+def test_tool_uses_defaults_and_passes_params():
+    searcher = FakeSearcher([CHAT_ROW])
+    tool = RecallTool(searcher, _cfg(scope_default="both", top_k=8))
+    out = asyncio.run(tool.execute(query="vectors"))
+    assert "chat ·" in out
+    call = searcher.calls[0]
+    assert call["scope"] == "both" and call["top_k"] == 8
+
+    asyncio.run(tool.execute(query="x", scope="memory", limit=3, date_from="2026-06-01"))
+    call = searcher.calls[1]
+    assert call["scope"] == "memory" and call["top_k"] == 3 and call["date_from"] == "2026-06-01"
+
+
+def test_tool_reports_unavailable():
+    tool = RecallTool(FakeSearcher([], ok=False, status="still preparing the search index"), _cfg())
+    out = asyncio.run(tool.execute(query="anything"))
+    assert out == "still preparing the search index"
+
+
+def test_tool_param_validation():
+    tool = RecallTool(FakeSearcher([]), _cfg())
+    assert tool.validate_params({"query": "x"}) == []
+    assert tool.validate_params({}) != []  # query required
+    assert tool.validate_params({"query": "x", "scope": "bogus"}) != []  # enum
+    assert tool.validate_params({"query": "x", "limit": 0}) != []  # minimum
+
+
+def test_tool_search_error_is_caught():
+    class Boom(FakeSearcher):
+        async def search(self, *a, **k):
+            raise RuntimeError("db gone")
+    tool = RecallTool(Boom([]), _cfg())
+    out = asyncio.run(tool.execute(query="x"))
+    assert "Recall search failed" in out

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,8 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version < '3.12'",
 ]
 
 [[package]]
@@ -560,6 +561,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -1380,6 +1389,182 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/5b8e2b85e81735696887175dbaf6409f215683f5ca9d4928fbb038211d32/onnxruntime-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:ff050e4f6bf7f12918fa14dcb047c0b02e295f35e86d42532552be4b3d54e977", size = 13356110, upload-time = "2026-06-15T22:43:32.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/4f568de678126b6a371a93862f015a82138359decd97fcac61fc84b5b774/onnxruntime-1.27.0-cp311-cp311-win_arm64.whl", hash = "sha256:75fbc1e1fb43a39a856c8209c544cca7817b5de7ac16b15b1bdf55d1cc67b9df", size = 13098635, upload-time = "2026-06-15T22:43:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/8ec9db1a4d126bb8b758992beb40d1249df171917d75f44a327eb5f20dda/onnxruntime-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:20c321cf187ba496e648acf6b4cf90b4d398b0d17c2a77fdaeba365b908cc1c1", size = 13358769, upload-time = "2026-06-15T22:43:34.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/fdad359dfcba7e7cd8815569b304a596531d4efa77a75d77f8b4981891a2/onnxruntime-1.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:d0d1f68868e2ef30ef70998ba9bbbc5c305e9b17041e3936751c1b8aa6aade06", size = 13104440, upload-time = "2026-06-15T22:43:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1548,6 +1733,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1835,21 +2035,27 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "anthropic" },
     { name = "croniter" },
     { name = "ddgs" },
     { name = "httpx" },
     { name = "litellm" },
     { name = "loguru" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "onnxruntime" },
     { name = "patchright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-telegram-bot" },
     { name = "readability-lxml" },
     { name = "rich" },
+    { name = "sqlite-vec" },
+    { name = "tokenizers" },
     { name = "typer" },
 ]
 
@@ -1862,12 +2068,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "croniter", specifier = ">=2.0.0" },
     { name = "ddgs", specifier = ">=9.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "litellm", specifier = ">=1.0.0" },
     { name = "loguru", specifier = ">=0.7.0" },
+    { name = "numpy", specifier = ">=1.26.0" },
+    { name = "onnxruntime", specifier = ">=1.20.0" },
     { name = "patchright", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -1877,6 +2086,8 @@ requires-dist = [
     { name = "readability-lxml", specifier = ">=0.8.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
+    { name = "tokenizers", specifier = ">=0.20.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
 provides-extras = ["dev"]
@@ -2208,6 +2419,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `recall` — hybrid (dense vector + BM25, RRF-fused) search over the agent's own memory notes and past chat history, exposed as a tool with `scope` (memory/chats/both, default both) and date/dialogue filters.
- Local and zero-touch: EmbeddingGemma-300m (q4 ONNX) on ONNX Runtime CPU + the sqlite-vec extension auto-provision on first use; the runtime libs ship in the base install. q4 chosen after measuring RAM/quality (int8 dynamic and GGUF were heavier on CPU).
- Background indexing on the existing memory-flush / compaction / new-chat triggers, plus a cheap reconcile backfill on every startup (cursor + content-hash + chunk-hash dedup). The message hot path only enqueues; all embed/chunk/DB work is off the event loop, and the index degrades gracefully if the platform can't load SQLite extensions.
- Tokenizer-accurate chunking: structure-aware with breadcrumbs for memory dumps; Q->A pairing (<=6 turns / <=512 tokens) with tool-noise/voice-tag filtering and a kept-if-substantive caption rule for chats. Every chunk is re-measured to stay within the 512-token cap.
- Per-profile storage under the data root; new `tools.recall` config block (quant, scope default, top_k, rrf_k, dates) with hot reload of the live fields.
- Agent-facing usage playbook for `recall` in BUILTIN_TOOLS.md.