### PR TITLE
feat: add OpenAI GPT-4o voice transcription

### DIFF
--- a/ragnarbot/agent/tools/secrets_helpers.py
+++ b/ragnarbot/agent/tools/secrets_helpers.py
@@ -50,6 +50,16 @@ CONFIG_DEPENDENCIES = [
         ["services.elevenlabs.api_key"],
         "requires secrets.services.elevenlabs.api_key",
     ),
+    ConfigDependency(
+        "transcription.provider", "openai-gpt-4o-transcribe", "exact",
+        ["providers.openai.api_key"],
+        "requires secrets.providers.openai.api_key",
+    ),
+    ConfigDependency(
+        "transcription.provider", "openai-gpt-4o-mini-transcribe", "exact",
+        ["providers.openai.api_key"],
+        "requires secrets.providers.openai.api_key",
+    ),
 ]
 
 

--- a/ragnarbot/channels/manager.py
+++ b/ragnarbot/channels/manager.py
@@ -50,7 +50,7 @@ class ChannelManager:
 
                 transcriber = create_transcription_provider(
                     self.config.transcription.provider,
-                    self.credentials.services,
+                    self.credentials,
                 )
                 self.channels["telegram"] = TelegramChannel(
                     self.config.channels.telegram,

--- a/ragnarbot/cli/tui/__init__.py
+++ b/ragnarbot/cli/tui/__init__.py
@@ -143,7 +143,21 @@ def _onboarding_loop(console: Console) -> None:
             step = 7
 
         elif step == 7:
-            result = voice_transcription_screen(console)
+            # An OpenAI transcription model reuses the OpenAI LLM key. It's
+            # available if entered earlier this run (api_key auth) or already saved.
+            from ragnarbot.auth.credentials import load_credentials
+
+            provider_id = PROVIDERS[provider_idx]["id"]
+            auth_method = "oauth" if auth_idx == 0 else "api_key"
+            openai_key_in_run = (
+                provider_id == "openai" and auth_method == "api_key" and bool(token)
+            )
+            openai_key_available = openai_key_in_run or bool(
+                load_credentials().providers.openai.api_key
+            )
+            result = voice_transcription_screen(
+                console, openai_key_available=openai_key_available
+            )
             if result is None:
                 step = 6
                 continue
@@ -280,6 +294,9 @@ def _save_results(
 
     if voice_api_key and voice_provider in ("groq", "elevenlabs"):
         getattr(creds.services, voice_provider).api_key = voice_api_key
+    elif voice_api_key and voice_provider.startswith("openai-"):
+        # OpenAI transcription shares the LLM provider key slot.
+        creds.providers.openai.api_key = voice_api_key
 
     if web_search_key:
         creds.services.brave_search.api_key = web_search_key

--- a/ragnarbot/cli/tui/screens.py
+++ b/ragnarbot/cli/tui/screens.py
@@ -196,9 +196,17 @@ def _validate_telegram_token(console: Console, token: str) -> str | None:
         return None
 
 
-def voice_transcription_screen(console: Console) -> tuple[str, str] | None:
-    """Voice transcription setup. Returns (provider, api_key), ("none","") for skip, or None (back)."""
+def voice_transcription_screen(
+    console: Console, openai_key_available: bool = False
+) -> tuple[str, str] | None:
+    """Voice transcription setup. Returns (provider, api_key), ("none","") for skip, or None (back).
+
+    When ``openai_key_available`` is True, an OpenAI model reuses the existing
+    OpenAI key (from the LLM provider step or a previous run) without prompting.
+    """
     voice_providers = [
+        ("OpenAI GPT-4o Transcribe", "Highest accuracy (needs OpenAI API key)"),
+        ("OpenAI GPT-4o Mini Transcribe", "Fast & cheaper (needs OpenAI API key)"),
         ("ElevenLabs (Scribe v2)", "Best quality, multilingual — recommended"),
         ("Groq (Whisper v3 Turbo)", "Fast and free"),
         ("Skip", "Disable voice transcription"),
@@ -211,11 +219,42 @@ def voice_transcription_screen(console: Console) -> tuple[str, str] | None:
     )
     if idx is None:
         return None
-    if idx == 2:
+    if idx == 4:
         return ("none", "")
 
-    provider_id = "elevenlabs" if idx == 0 else "groq"
-    provider_label = "ElevenLabs" if idx == 0 else "Groq"
+    # OpenAI models — key comes from the shared OpenAI provider slot.
+    if idx in (0, 1):
+        provider_value = (
+            "openai-gpt-4o-transcribe" if idx == 0 else "openai-gpt-4o-mini-transcribe"
+        )
+        if openai_key_available:
+            ok = info_screen(
+                console,
+                "Using your existing OpenAI key",
+                [
+                    "Your OpenAI API key is already configured, so we'll reuse it",
+                    "for voice transcription — no need to enter it again.",
+                ],
+                subtitle="Step 7 of 9 — OpenAI",
+            )
+            if not ok:
+                return None
+            return (provider_value, "")
+
+        api_key = text_input(
+            console,
+            "OpenAI API key",
+            "API key",
+            hint="Get your API key at: https://platform.openai.com/api-keys",
+            secret=False,
+            subtitle="Step 7 of 9 — OpenAI",
+        )
+        if api_key is None:
+            return None
+        return (provider_value, api_key)
+
+    provider_id = "elevenlabs" if idx == 2 else "groq"
+    provider_label = "ElevenLabs" if idx == 2 else "Groq"
 
     api_key = text_input(
         console,
@@ -318,7 +357,13 @@ def summary_screen(
     search_engine: str = "none",
 ) -> bool:
     """Show summary of configured values. Returns True on Enter."""
-    voice_label = {"groq": "Groq", "elevenlabs": "ElevenLabs", "none": "Skipped"}
+    voice_label = {
+        "groq": "Groq",
+        "elevenlabs": "ElevenLabs",
+        "openai-gpt-4o-transcribe": "OpenAI GPT-4o Transcribe",
+        "openai-gpt-4o-mini-transcribe": "OpenAI GPT-4o Mini Transcribe",
+        "none": "Skipped",
+    }
     search_label = {"brave": "Brave Search", "duckduckgo": "DuckDuckGo", "none": "Skipped"}
     lightning_resolution = resolve_lightning(model_id, auth_method, lightning_mode)
     needs_codex_cli = auth_method == "oauth" and lightning_resolution.supported and not is_codex_cli_available()

--- a/ragnarbot/config/schema.py
+++ b/ragnarbot/config/schema.py
@@ -278,7 +278,7 @@ class TranscriptionConfig(BaseModel):
     """Voice transcription configuration."""
     provider: str = Field(
         default="none",
-        pattern="^(groq|elevenlabs|none)$",
+        pattern="^(groq|elevenlabs|openai-gpt-4o-transcribe|openai-gpt-4o-mini-transcribe|none)$",
         json_schema_extra={"reload": "warm", "label": "Voice transcription provider"},
     )
 

--- a/ragnarbot/providers/transcription.py
+++ b/ragnarbot/providers/transcription.py
@@ -1,4 +1,4 @@
-"""Voice transcription providers (Groq Whisper, ElevenLabs Scribe)."""
+"""Voice transcription providers (Groq Whisper, ElevenLabs Scribe, OpenAI GPT-4o)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,13 @@ from pathlib import Path
 import httpx
 from loguru import logger
 
-from ragnarbot.auth.credentials import ServicesCredentials
+from ragnarbot.auth.credentials import Credentials
+
+# Maps a transcription provider value to the concrete OpenAI model id.
+OPENAI_TRANSCRIPTION_MODELS = {
+    "openai-gpt-4o-transcribe": "gpt-4o-transcribe",
+    "openai-gpt-4o-mini-transcribe": "gpt-4o-mini-transcribe",
+}
 
 
 class TranscriptionError(Exception):
@@ -104,11 +110,52 @@ class ElevenLabsTranscriptionProvider(TranscriptionProvider):
             raise TranscriptionError("transcription failed", str(e)) from e
 
 
+class OpenAITranscriptionProvider(TranscriptionProvider):
+    """OpenAI GPT-4o transcription (gpt-4o-transcribe / gpt-4o-mini-transcribe)."""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o-transcribe"):
+        self.api_key = api_key
+        self.model = model
+        self.api_url = "https://api.openai.com/v1/audio/transcriptions"
+
+    async def transcribe(self, file_path: str | Path) -> str:
+        path = Path(file_path)
+        if not path.exists():
+            raise TranscriptionError("file not found", f"Audio file not found: {path}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                with open(path, "rb") as f:
+                    response = await client.post(
+                        self.api_url,
+                        headers={"Authorization": f"Bearer {self.api_key}"},
+                        files={"file": (path.name, f), "model": (None, self.model)},
+                        data={"response_format": "json"},
+                        timeout=60.0,
+                    )
+                response.raise_for_status()
+                text = response.json().get("text", "").strip()
+                if not text:
+                    raise TranscriptionError("empty response", "OpenAI returned empty text")
+                return text
+        except TranscriptionError:
+            raise
+        except httpx.HTTPStatusError as e:
+            detail = f"OpenAI API {e.response.status_code}: {e.response.text[:200]}"
+            logger.error(detail)
+            raise TranscriptionError("API error", detail) from e
+        except Exception as e:
+            logger.error(f"OpenAI transcription error: {e}")
+            raise TranscriptionError("transcription failed", str(e)) from e
+
+
 def create_transcription_provider(
     provider_name: str,
-    services: ServicesCredentials,
+    credentials: Credentials,
 ) -> TranscriptionProvider | None:
     """Factory: create a transcription provider by name, or None if disabled."""
+    services = credentials.services
+
     if provider_name == "groq":
         key = services.groq.api_key
         if not key:
@@ -122,5 +169,13 @@ def create_transcription_provider(
             logger.warning("ElevenLabs transcription selected but no API key configured")
             return None
         return ElevenLabsTranscriptionProvider(key)
+
+    if provider_name in OPENAI_TRANSCRIPTION_MODELS:
+        # OpenAI transcription reuses the LLM provider key (shared token store).
+        key = credentials.providers.openai.api_key
+        if not key:
+            logger.warning("OpenAI transcription selected but no OpenAI API key configured")
+            return None
+        return OpenAITranscriptionProvider(key, OPENAI_TRANSCRIPTION_MODELS[provider_name])
 
     return None

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -106,8 +106,10 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),         # Select first model (Opus)
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),         # Skip telegram (empty enter)
-            (Key.DOWN, ""),          # Voice: past ElevenLabs
-            (Key.DOWN, ""),          # Voice: to Skip
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
+            (Key.DOWN, ""),         # Voice: past ElevenLabs
+            (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),         # Select Skip
             *SKIP_WEB_SEARCH,       # Skip web search
             (Key.DOWN, ""),          # Navigate to "No" (manual start)
@@ -137,6 +139,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select Sonnet
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -166,6 +170,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select first model (GPT-5.5)
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -238,6 +244,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select Flash
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -267,6 +275,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -291,6 +301,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select first model
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -358,6 +370,8 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -402,6 +416,8 @@ class TestTelegramValidation:
             *[(Key.CHAR, c) for c in "123456:ABC-DEF"],
             (Key.ENTER, ""),        # Submit token
             (Key.ENTER, ""),        # Accept bot info screen
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -472,6 +488,8 @@ class TestVoiceTranscriptionOnboarding:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs to Groq
             (Key.ENTER, ""),        # Select Groq
             *[(Key.CHAR, c) for c in "gsk-groq-key"],
@@ -489,6 +507,62 @@ class TestVoiceTranscriptionOnboarding:
         creds = mock_save_creds.call_args[0][0]
         assert creds.services.groq.api_key == "gsk-groq-key"
 
+    def test_openai_voice_selection_prompts_for_key(self, tmp_path):
+        """Select OpenAI GPT-4o Transcribe with no OpenAI key yet — prompt and save it."""
+        keys = [
+            (Key.ENTER, ""),        # Select Anthropic
+            (Key.DOWN, ""),         # Navigate to API Key
+            (Key.ENTER, ""),        # Select API Key
+            *[(Key.CHAR, c) for c in "sk-ant-key"],
+            (Key.ENTER, ""),        # Confirm key
+            (Key.ENTER, ""),        # Select first model
+            *SKIP_LIGHTNING,
+            (Key.ENTER, ""),        # Skip telegram
+            (Key.ENTER, ""),        # Voice: select OpenAI GPT-4o Transcribe (first option)
+            *[(Key.CHAR, c) for c in "sk-openai-voice"],
+            (Key.ENTER, ""),        # Confirm OpenAI key
+            *SKIP_WEB_SEARCH,      # Skip web search
+            (Key.DOWN, ""),         # Navigate to "No" (manual start)
+            (Key.ENTER, ""),        # Select manual start
+            (Key.ENTER, ""),        # Confirm summary
+        ]
+        mock_save_config, mock_save_creds = self._run_with_keys(keys, tmp_path)
+
+        config = mock_save_config.call_args[0][0]
+        assert config.transcription.provider == "openai-gpt-4o-transcribe"
+
+        creds = mock_save_creds.call_args[0][0]
+        assert creds.providers.openai.api_key == "sk-openai-voice"
+
+    def test_openai_voice_reuses_existing_key(self, tmp_path):
+        """OpenAI chosen as LLM with API key — voice reuses it without re-prompting."""
+        keys = [
+            (Key.DOWN, ""),         # Navigate to OpenAI
+            (Key.ENTER, ""),        # Select OpenAI
+            (Key.DOWN, ""),         # Navigate to API Key
+            (Key.ENTER, ""),        # Select API Key
+            *[(Key.CHAR, c) for c in "sk-openai-llm"],
+            (Key.ENTER, ""),        # Confirm key
+            (Key.ENTER, ""),        # Select first model (GPT-5.5)
+            *SKIP_LIGHTNING,
+            (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: to OpenAI GPT-4o Mini Transcribe
+            (Key.ENTER, ""),        # Select OpenAI GPT-4o Mini Transcribe
+            (Key.ENTER, ""),        # Acknowledge "using your existing OpenAI key" notice
+            *SKIP_WEB_SEARCH,      # Skip web search
+            (Key.DOWN, ""),         # Navigate to "No" (manual start)
+            (Key.ENTER, ""),        # Select manual start
+            (Key.ENTER, ""),        # Confirm summary
+        ]
+        mock_save_config, mock_save_creds = self._run_with_keys(keys, tmp_path)
+
+        config = mock_save_config.call_args[0][0]
+        assert config.transcription.provider == "openai-gpt-4o-mini-transcribe"
+
+        creds = mock_save_creds.call_args[0][0]
+        # Reused the LLM key; the voice step neither re-prompted nor changed it.
+        assert creds.providers.openai.api_key == "sk-openai-llm"
+
     def test_web_search_brave_with_key(self, tmp_path):
         """Select Brave Search and provide API key during onboarding."""
         keys = [
@@ -500,6 +574,8 @@ class TestVoiceTranscriptionOnboarding:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -529,6 +605,8 @@ class TestVoiceTranscriptionOnboarding:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip
@@ -554,6 +632,8 @@ class TestVoiceTranscriptionOnboarding:
             (Key.ENTER, ""),        # Select first model
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
+            (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
+            (Key.DOWN, ""),         # Voice: past OpenAI Mini Transcribe
             (Key.DOWN, ""),         # Voice: past ElevenLabs
             (Key.DOWN, ""),         # Voice: to Skip
             (Key.ENTER, ""),        # Select Skip

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -2,10 +2,11 @@
 
 import pytest
 
-from ragnarbot.auth.credentials import ServicesCredentials
+from ragnarbot.auth.credentials import Credentials
 from ragnarbot.providers.transcription import (
     ElevenLabsTranscriptionProvider,
     GroqTranscriptionProvider,
+    OpenAITranscriptionProvider,
     TranscriptionError,
     TranscriptionProvider,
     create_transcription_provider,
@@ -49,35 +50,70 @@ class TestElevenLabsProvider:
             await provider.transcribe(tmp_path / "nonexistent.ogg")
 
 
+class TestOpenAIProvider:
+    def test_is_transcription_provider(self):
+        provider = OpenAITranscriptionProvider(api_key="sk-test")
+        assert isinstance(provider, TranscriptionProvider)
+
+    def test_default_model(self):
+        provider = OpenAITranscriptionProvider(api_key="sk-test")
+        assert provider.model == "gpt-4o-transcribe"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises(self, tmp_path):
+        provider = OpenAITranscriptionProvider(api_key="sk-test")
+        with pytest.raises(TranscriptionError, match="file not found"):
+            await provider.transcribe(tmp_path / "nonexistent.ogg")
+
+
 class TestFactory:
     def test_groq_with_key(self):
-        services = ServicesCredentials()
-        services.groq.api_key = "gsk-test"
-        provider = create_transcription_provider("groq", services)
+        creds = Credentials()
+        creds.services.groq.api_key = "gsk-test"
+        provider = create_transcription_provider("groq", creds)
         assert isinstance(provider, GroqTranscriptionProvider)
 
     def test_elevenlabs_with_key(self):
-        services = ServicesCredentials()
-        services.elevenlabs.api_key = "xi-test"
-        provider = create_transcription_provider("elevenlabs", services)
+        creds = Credentials()
+        creds.services.elevenlabs.api_key = "xi-test"
+        provider = create_transcription_provider("elevenlabs", creds)
         assert isinstance(provider, ElevenLabsTranscriptionProvider)
 
+    def test_openai_transcribe_with_key(self):
+        creds = Credentials()
+        creds.providers.openai.api_key = "sk-test"
+        provider = create_transcription_provider("openai-gpt-4o-transcribe", creds)
+        assert isinstance(provider, OpenAITranscriptionProvider)
+        assert provider.model == "gpt-4o-transcribe"
+
+    def test_openai_mini_transcribe_with_key(self):
+        creds = Credentials()
+        creds.providers.openai.api_key = "sk-test"
+        provider = create_transcription_provider("openai-gpt-4o-mini-transcribe", creds)
+        assert isinstance(provider, OpenAITranscriptionProvider)
+        assert provider.model == "gpt-4o-mini-transcribe"
+
     def test_groq_without_key_returns_none(self):
-        services = ServicesCredentials()
-        provider = create_transcription_provider("groq", services)
+        creds = Credentials()
+        provider = create_transcription_provider("groq", creds)
         assert provider is None
 
     def test_elevenlabs_without_key_returns_none(self):
-        services = ServicesCredentials()
-        provider = create_transcription_provider("elevenlabs", services)
+        creds = Credentials()
+        provider = create_transcription_provider("elevenlabs", creds)
+        assert provider is None
+
+    def test_openai_without_key_returns_none(self):
+        creds = Credentials()
+        provider = create_transcription_provider("openai-gpt-4o-transcribe", creds)
         assert provider is None
 
     def test_none_provider(self):
-        services = ServicesCredentials()
-        provider = create_transcription_provider("none", services)
+        creds = Credentials()
+        provider = create_transcription_provider("none", creds)
         assert provider is None
 
     def test_unknown_provider(self):
-        services = ServicesCredentials()
-        provider = create_transcription_provider("whisperx", services)
+        creds = Credentials()
+        provider = create_transcription_provider("whisperx", creds)
         assert provider is None


### PR DESCRIPTION
## Summary

- Add `OpenAITranscriptionProvider` with two selectable models: GPT-4o Transcribe (`gpt-4o-transcribe`) and GPT-4o Mini Transcribe (`gpt-4o-mini-transcribe`), calling `/v1/audio/transcriptions` over httpx like the existing Groq/ElevenLabs providers.
- Reuse the shared OpenAI key slot (`providers.openai.api_key`): onboarding does not re-prompt when an OpenAI key already exists (from the LLM step or a previous run), and prompts + saves there otherwise.
- Wire the two new provider values through the config schema pattern, the secrets-dependency check, the onboarding menu/summary, and the channel manager.
- Tests: extend transcription factory/provider coverage and add onboarding cases for both the prompt-for-key and reuse-existing-key paths.

Telegram voice messages are `.ogg`, which the OpenAI transcription endpoint supports, so no conversion is needed.