### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.10.0"
+version = "0.11.0"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __logo__ = "🤖"


### PR DESCRIPTION
## Summary

- Bump version to 0.11.0 for the OpenAI GPT-4o voice transcription release.