### PR TITLE
release: v0.11.3 model routing and subprocess reliability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.1"
+version = "0.11.2"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.0"
+version = "0.11.1"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.2"
+version = "0.11.3"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 __logo__ = "🤖"

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __logo__ = "🤖"

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 __logo__ = "🤖"

--- a/ragnarbot/agent/background.py
+++ b/ragnarbot/agent/background.py
@@ -1,6 +1,7 @@
 """Background process manager for async command execution."""
 
 import asyncio
+import contextlib
 import re
 import time
 import uuid
@@ -13,6 +14,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from ragnarbot.agent.pathing import resolve_working_dir
+from ragnarbot.agent.processes import isolated_process_kwargs, terminate_process_tree
 from ragnarbot.bus.events import InboundMessage
 
 if TYPE_CHECKING:
@@ -169,11 +171,19 @@ class BackgroundProcessManager:
         try:
             process = await asyncio.create_subprocess_shell(
                 job.command,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=job.working_dir,
+                **isolated_process_kwargs(),
             )
             job.process = process
+
+            # ``kill`` can race with subprocess creation. Do not let a job that
+            # was cancelled before assignment escape as an untracked process.
+            if job.status == JobState.killed:
+                await terminate_process_tree(process)
+                return
 
             async def _read_stream(stream: asyncio.StreamReader, buf: deque):
                 async for line in stream:
@@ -188,19 +198,34 @@ class BackgroundProcessManager:
                 await asyncio.wait_for(readers, timeout=MAX_RUNTIME)
                 await process.wait()
             except asyncio.TimeoutError:
-                process.kill()
-                await process.wait()
+                await terminate_process_tree(process)
                 job.status = JobState.killed
                 job.exit_code = process.returncode
                 job.finished_at = time.time()
                 await self._announce_completion(job, timed_out=True)
                 return
 
+            if job.status == JobState.killed:
+                return
+
             job.exit_code = process.returncode
             job.finished_at = time.time()
             job.status = JobState.completed if process.returncode == 0 else JobState.error
 
+        except asyncio.CancelledError:
+            if job.process is not None:
+                with contextlib.suppress(Exception):
+                    await terminate_process_tree(job.process)
+            job.status = JobState.killed
+            job.exit_code = job.process.returncode if job.process else None
+            job.finished_at = time.time()
+            raise
         except Exception as e:
+            if job.process is not None:
+                with contextlib.suppress(Exception):
+                    await terminate_process_tree(job.process)
+            if job.status == JobState.killed:
+                return
             logger.error(f"Background job [{job.job_id}] failed: {e}")
             job.status = JobState.error
             job.finished_at = time.time()
@@ -358,20 +383,25 @@ Report this status to the user naturally."""
             return f"Poll {job_id} cancelled."
 
         # Real process
-        if job.process:
-            try:
-                job.process.terminate()
-                try:
-                    await asyncio.wait_for(job.process.wait(), timeout=3)
-                except asyncio.TimeoutError:
-                    job.process.kill()
-                    await job.process.wait()
-            except ProcessLookupError:
-                pass
-
         job.status = JobState.killed
-        job.exit_code = job.process.returncode if job.process else None
         job.finished_at = time.time()
+
+        if job.process:
+            await terminate_process_tree(job.process)
+            job.exit_code = job.process.returncode
+            if job.task and job.task is not asyncio.current_task() and not job.task.done():
+                try:
+                    await asyncio.wait_for(job.task, timeout=2)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    if not job.task.done():
+                        job.task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await job.task
+        elif job.task:
+            job.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await job.task
+
         return f"Job {job_id} killed."
 
     def dismiss(self, job_id: str) -> str:

--- a/ragnarbot/agent/background.py
+++ b/ragnarbot/agent/background.py
@@ -189,14 +189,14 @@ class BackgroundProcessManager:
                 async for line in stream:
                     buf.append(line.decode("utf-8", errors="replace").rstrip("\n"))
 
-            readers = asyncio.gather(
+            lifecycle = asyncio.gather(
                 _read_stream(process.stdout, job.stdout_buffer),
                 _read_stream(process.stderr, job.stderr_buffer),
+                process.wait(),
             )
 
             try:
-                await asyncio.wait_for(readers, timeout=MAX_RUNTIME)
-                await process.wait()
+                await asyncio.wait_for(lifecycle, timeout=MAX_RUNTIME)
             except asyncio.TimeoutError:
                 await terminate_process_tree(process)
                 job.status = JobState.killed

--- a/ragnarbot/agent/background.py
+++ b/ragnarbot/agent/background.py
@@ -28,6 +28,16 @@ OUTPUT_BUFFER_LINES = 1000
 AUTO_DISMISS_SECONDS = 300  # 5 minutes
 
 
+async def _cancel_and_await_lifecycle(lifecycle: asyncio.Future | None) -> None:
+    """Cancel and retrieve a job lifecycle future without leaking warnings."""
+    if lifecycle is None:
+        return
+    if not lifecycle.done():
+        lifecycle.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await lifecycle
+
+
 class JobState(str, Enum):
     running = "running"
     completed = "completed"
@@ -168,6 +178,7 @@ class BackgroundProcessManager:
 
     async def _run_job(self, job: BgJob) -> None:
         """Execute subprocess, capture output, announce result on completion."""
+        lifecycle: asyncio.Future | None = None
         try:
             process = await asyncio.create_subprocess_shell(
                 job.command,
@@ -198,7 +209,10 @@ class BackgroundProcessManager:
             try:
                 await asyncio.wait_for(lifecycle, timeout=MAX_RUNTIME)
             except asyncio.TimeoutError:
+                await _cancel_and_await_lifecycle(lifecycle)
                 await terminate_process_tree(process)
+                if job.status == JobState.killed:
+                    return
                 job.status = JobState.killed
                 job.exit_code = process.returncode
                 job.finished_at = time.time()
@@ -213,6 +227,7 @@ class BackgroundProcessManager:
             job.status = JobState.completed if process.returncode == 0 else JobState.error
 
         except asyncio.CancelledError:
+            await _cancel_and_await_lifecycle(lifecycle)
             if job.process is not None:
                 with contextlib.suppress(Exception):
                     await terminate_process_tree(job.process)
@@ -221,6 +236,7 @@ class BackgroundProcessManager:
             job.finished_at = time.time()
             raise
         except Exception as e:
+            await _cancel_and_await_lifecycle(lifecycle)
             if job.process is not None:
                 with contextlib.suppress(Exception):
                     await terminate_process_tree(job.process)

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -520,6 +521,42 @@ class AgentLoop:
             return None
         return chat_task.result()
 
+    async def _chat_route_observed(
+        self,
+        session_key: str | None,
+        *,
+        route: str,
+        model: str,
+        provider: LLMProvider,
+        chat_kwargs: dict[str, Any],
+    ) -> LLMResponse | None:
+        """Call one provider route and log timing without request content."""
+        started_at = time.monotonic()
+        try:
+            if session_key:
+                response = await self._chat_or_stop(
+                    session_key, provider=provider, **chat_kwargs,
+                )
+            else:
+                response = await provider.chat(**chat_kwargs)
+        except Exception as exc:
+            elapsed = time.monotonic() - started_at
+            logger.error(
+                f"LLM call raised: route={route} model={model} "
+                f"elapsed_s={elapsed:.3f} error_type={type(exc).__name__}"
+            )
+            raise
+
+        elapsed = time.monotonic() - started_at
+        finish_reason = response.finish_reason if response is not None else "cancelled"
+        response_type = type(response).__name__ if response is not None else "None"
+        logger.info(
+            f"LLM call completed: route={route} model={model} "
+            f"elapsed_s={elapsed:.3f} finish_reason={finish_reason} "
+            f"response_type={response_type}"
+        )
+        return response
+
     def _get_or_create_fallback_provider(self) -> LLMProvider | None:
         """Lazily create the fallback provider on first use."""
         if self._fallback_provider is not None:
@@ -544,6 +581,7 @@ class AgentLoop:
         *,
         notify_channel: str | None = None,
         notify_chat_id: str | None = None,
+        force_fallback: bool = False,
         **chat_kwargs,
     ) -> tuple[LLMResponse | None, bool, str | None]:
         """Call primary LLM with automatic fallback on error.
@@ -563,8 +601,13 @@ class AgentLoop:
         )
         use_primary = (
             not has_fallback
-            or not state.fallback_mode
-            or state.should_probe_primary(probe_interval)
+            or (
+                not force_fallback
+                and (
+                    not state.fallback_mode
+                    or state.should_probe_primary(probe_interval)
+                )
+            )
         )
         response = None
         primary_error = None
@@ -579,12 +622,13 @@ class AgentLoop:
                 state.mark_primary_probed()
                 logger.info("Probing primary provider for recovery...")
 
-            if session_key:
-                response = await self._chat_or_stop(
-                    session_key, provider=self.provider, **chat_kwargs,
-                )
-            else:
-                response = await self.provider.chat(**chat_kwargs)
+            response = await self._chat_route_observed(
+                session_key,
+                route="primary",
+                model=str(chat_kwargs["model"]),
+                provider=self.provider,
+                chat_kwargs=chat_kwargs,
+            )
 
             if response is None:
                 return None, False, None  # stopped by user
@@ -628,12 +672,13 @@ class AgentLoop:
         logger.info(f"Using fallback provider: {self._fallback_model}")
 
         chat_kwargs["model"] = self._fallback_model
-        if session_key:
-            fb_response = await self._chat_or_stop(
-                session_key, provider=fb_provider, **chat_kwargs,
-            )
-        else:
-            fb_response = await fb_provider.chat(**chat_kwargs)
+        fb_response = await self._chat_route_observed(
+            session_key,
+            route="fallback",
+            model=self._fallback_model,
+            provider=fb_provider,
+            chat_kwargs=chat_kwargs,
+        )
 
         if fb_response is None:
             return None, True, primary_error  # stopped by user
@@ -1427,6 +1472,7 @@ class AgentLoop:
                     session_key,
                     notify_channel=msg.channel,
                     notify_chat_id=msg.chat_id,
+                    force_fallback=batch_used_fallback,
                     messages=api_messages,
                     tools=tools_defs,
                     tool_runner=self._make_provider_tool_runner(session_key),
@@ -2443,6 +2489,7 @@ class AgentLoop:
                     session_key,
                     notify_channel=origin_channel,
                     notify_chat_id=origin_chat_id,
+                    force_fallback=batch_used_fallback,
                     messages=api_messages,
                     tools=tools_defs,
                     tool_runner=self._make_provider_tool_runner(session_key),

--- a/ragnarbot/agent/loop.py
+++ b/ragnarbot/agent/loop.py
@@ -3057,6 +3057,7 @@ class AgentLoop:
             chat_kwargs["tools"] = tools_defs
             response, used_fallback, _ = await self._chat_with_fallback(
                 None,
+                force_fallback=batch_used_fallback,
                 **chat_kwargs,
             )
             if used_fallback:
@@ -3151,6 +3152,7 @@ class AgentLoop:
             chat_kwargs["tools"] = tools_defs
             response, used_fallback, _ = await self._chat_with_fallback(
                 None,
+                force_fallback=batch_used_fallback,
                 **chat_kwargs,
             )
             if used_fallback:
@@ -3281,6 +3283,7 @@ class AgentLoop:
             ]
             response, used_fallback, _ = await self._chat_with_fallback(
                 None,
+                force_fallback=batch_used_fallback,
                 messages=api_messages, tools=tools_defs,
             )
             if used_fallback:

--- a/ragnarbot/agent/processes.py
+++ b/ragnarbot/agent/processes.py
@@ -1,0 +1,118 @@
+"""Shared subprocess lifecycle helpers for shell-backed tools."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+from typing import Any
+
+
+def isolated_process_kwargs() -> dict[str, Any]:
+    """Return platform-specific flags that isolate a subprocess tree."""
+    if os.name == "posix":
+        return {"start_new_session": True}
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {}
+
+
+async def _wait_for_process(process: asyncio.subprocess.Process, timeout: float) -> bool:
+    if process.returncode is not None:
+        return True
+    try:
+        await asyncio.wait_for(process.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        return False
+    return True
+
+
+def _signal_process_group(pid: int, sig: signal.Signals) -> bool:
+    try:
+        os.killpg(pid, sig)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return False
+    return True
+
+
+def _process_group_exists(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def _wait_for_process_group(pid: int, timeout: float) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _process_group_exists(pid):
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.05)
+    return True
+
+
+async def _terminate_windows_tree(process: asyncio.subprocess.Process, timeout: float) -> None:
+    """Best-effort tree termination on Windows via the built-in taskkill utility."""
+    try:
+        killer = await asyncio.create_subprocess_exec(
+            "taskkill",
+            "/PID",
+            str(process.pid),
+            "/T",
+            "/F",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(killer.wait(), timeout=timeout)
+    except (FileNotFoundError, ProcessLookupError, asyncio.TimeoutError):
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+    await _wait_for_process(process, timeout)
+
+
+async def terminate_process_tree(
+    process: asyncio.subprocess.Process,
+    *,
+    grace_period: float = 1.0,
+) -> None:
+    """Terminate a subprocess and every descendant, then reap the leader.
+
+    Shell tools spawn each command in its own process group/session. Signalling
+    only the shell leaves children such as ``npm``, ``npx``, and backgrounded
+    scripts alive after a timeout, so POSIX cleanup targets the entire group.
+    """
+    grace_period = max(grace_period, 0.1)
+
+    if os.name == "nt":
+        await _terminate_windows_tree(process, grace_period)
+        return
+
+    if os.name != "posix":
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                process.terminate()
+        if not await _wait_for_process(process, grace_period):
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await _wait_for_process(process, grace_period)
+        return
+
+    pid = process.pid
+    _signal_process_group(pid, signal.SIGTERM)
+    leader_done = await _wait_for_process(process, grace_period)
+    group_done = await _wait_for_process_group(pid, grace_period)
+    if leader_done and group_done:
+        return
+
+    _signal_process_group(pid, signal.SIGKILL)
+    await _wait_for_process(process, grace_period)
+    await _wait_for_process_group(pid, grace_period)

--- a/ragnarbot/agent/subagent.py
+++ b/ragnarbot/agent/subagent.py
@@ -99,6 +99,7 @@ class SubagentManager:
             self._chat_fn = chat_fn
         else:
             async def _default(session_key=None, **kwargs):
+                kwargs.pop("force_fallback", None)
                 return await self.provider.chat(**kwargs), False, None
             self._chat_fn = _default
         self._on_fallback_batch = on_fallback_batch
@@ -250,7 +251,11 @@ class SubagentManager:
                 if reasoning_level is not None:
                     chat_kwargs["reasoning_level"] = reasoning_level
 
-                response, used_fallback, _ = await self._chat_fn(None, **chat_kwargs)
+                response, used_fallback, _ = await self._chat_fn(
+                    None,
+                    force_fallback=batch_used_fallback,
+                    **chat_kwargs,
+                )
                 if used_fallback:
                     batch_used_fallback = True
 

--- a/ragnarbot/agent/tools/background.py
+++ b/ragnarbot/agent/tools/background.py
@@ -29,8 +29,9 @@ class ExecBgTool(Tool):
         return (
             "Execute a shell command in the background. The command runs asynchronously "
             "and you'll be notified when it completes. Use for long-running tasks "
-            "(builds, image generation, data processing). Use 'output' to check progress, "
-            "'kill' to stop, 'poll' to schedule a status check."
+            "(package installs, builds, downloads, image generation, data processing). "
+            "Commands must be non-interactive because stdin is unavailable. Use 'output' "
+            "to check progress, 'kill' to stop, 'poll' to schedule a status check."
         )
 
     @property

--- a/ragnarbot/agent/tools/browser.py
+++ b/ragnarbot/agent/tools/browser.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from ragnarbot.agent.processes import isolated_process_kwargs, terminate_process_tree
 from ragnarbot.agent.tools.base import Tool
 from ragnarbot.instance import ensure_instance_root
 
@@ -35,6 +36,7 @@ STEALTH_ARGS = [
 ]
 
 GOTO_TIMEOUT_MS = 30_000  # 30s navigation timeout
+BROWSER_INSTALL_TIMEOUT_SECONDS = 900
 
 
 def _build_brand_header(major: str) -> str:
@@ -122,19 +124,33 @@ class BrowserSessionManager:
         logger.info("Installing Chromium browser (first-time setup)...")
         proc = await asyncio.create_subprocess_exec(
             sys.executable, "-m", "patchright", "install", "chromium",
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            **isolated_process_kwargs(),
         )
         try:
-            await proc.wait()
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=BROWSER_INSTALL_TIMEOUT_SECONDS,
+            )
         except asyncio.CancelledError:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
+            await terminate_process_tree(proc)
+            raise
+        except asyncio.TimeoutError as exc:
+            await terminate_process_tree(proc)
+            raise RuntimeError(
+                "Chromium installation timed out after "
+                f"{BROWSER_INSTALL_TIMEOUT_SECONDS} seconds. "
+                "Run manually: patchright install chromium"
+            ) from exc
+        except Exception:
+            await terminate_process_tree(proc)
             raise
         if proc.returncode != 0:
+            output = (stderr or stdout or b"").decode("utf-8", errors="replace").strip()
+            detail = output.splitlines()[-1] if output else "installer exited with an error"
             raise RuntimeError(
-                "Failed to install Chromium. Run manually: patchright install chromium"
+                f"Failed to install Chromium: {detail}. "
+                "Run manually: patchright install chromium"
             )
         logger.info("Chromium installed.")
         self._chromium_installed = True

--- a/ragnarbot/agent/tools/shell.py
+++ b/ragnarbot/agent/tools/shell.py
@@ -1,11 +1,13 @@
 """Shell execution tool."""
 
 import asyncio
+import contextlib
 import re
 from pathlib import Path
 from typing import Any
 
 from ragnarbot.agent.pathing import resolve_working_dir
+from ragnarbot.agent.processes import isolated_process_kwargs, terminate_process_tree
 from ragnarbot.agent.tools.base import Tool
 
 
@@ -43,7 +45,11 @@ class ExecTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Execute a shell command and return its output. Use with caution."
+        return (
+            "Execute a short, non-interactive shell command and return its output. "
+            "Use exec_bg for package installs, downloads, builds, or anything that may take "
+            "more than a few seconds."
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -72,9 +78,11 @@ class ExecTool(Tool):
         try:
             process = await asyncio.create_subprocess_shell(
                 command,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(cwd),
+                **isolated_process_kwargs(),
             )
 
             try:
@@ -83,18 +91,11 @@ class ExecTool(Tool):
                     timeout=self.timeout
                 )
             except asyncio.CancelledError:
-                if process.returncode is None:
-                    try:
-                        process.kill()
-                    except ProcessLookupError:
-                        pass
-                    try:
-                        await process.wait()
-                    except Exception:
-                        pass
+                with contextlib.suppress(Exception):
+                    await terminate_process_tree(process)
                 raise
             except asyncio.TimeoutError:
-                process.kill()
+                await terminate_process_tree(process)
                 return f"Error: Command timed out after {self.timeout} seconds"
 
             output_parts = []
@@ -122,6 +123,9 @@ class ExecTool(Tool):
         except asyncio.CancelledError:
             raise
         except Exception as e:
+            if process is not None:
+                with contextlib.suppress(Exception):
+                    await terminate_process_tree(process)
             return f"Error executing command: {str(e)}"
 
     def _guard_command(self, command: str, cwd: str) -> str | None:

--- a/ragnarbot/agent/tools/update.py
+++ b/ragnarbot/agent/tools/update.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 import ragnarbot
+from ragnarbot.agent.processes import isolated_process_kwargs, terminate_process_tree
 from ragnarbot.agent.tools.base import Tool
 from ragnarbot.instance import (
     clear_pending_update,
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
 
 GITHUB_REPO = "BlckLvls/ragnarbot"
 GITHUB_API = f"https://api.github.com/repos/{GITHUB_REPO}"
+UPGRADE_TIMEOUT_SECONDS = 600
 
 
 def get_update_marker_path():
@@ -282,22 +284,27 @@ class UpdateTool(Tool):
 
     @staticmethod
     async def _run_subprocess(*argv: str) -> tuple[int, bytes, bytes]:
-        """Run a subprocess and ensure it is killed on cancellation."""
+        """Run an installer with a bounded lifetime and process-tree cleanup."""
         proc = await asyncio.create_subprocess_exec(
             *argv,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            **isolated_process_kwargs(),
         )
         try:
-            stdout, stderr = await proc.communicate()
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=UPGRADE_TIMEOUT_SECONDS,
+            )
         except asyncio.CancelledError:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            try:
-                await proc.wait()
-            except Exception:
-                pass
+            await terminate_process_tree(proc)
+            raise
+        except asyncio.TimeoutError as exc:
+            await terminate_process_tree(proc)
+            raise RuntimeError(
+                f"Upgrade command timed out after {UPGRADE_TIMEOUT_SECONDS} seconds"
+            ) from exc
+        except Exception:
+            await terminate_process_tree(proc)
             raise
         return proc.returncode or 0, stdout, stderr

--- a/ragnarbot/builtin/AGENTS.md
+++ b/ragnarbot/builtin/AGENTS.md
@@ -310,13 +310,16 @@ You have two ways to run shell commands: `exec` (synchronous) and `exec_bg` (bac
 
 ### When to Use `exec` (Synchronous)
 
-Use `exec` for anything that completes in a few seconds: listing files, running a quick API call, checking a status, installing a package, simple scripts. Even if you need to run several of these in sequence or parallel, stick with `exec` — launching them as background jobs adds overhead for no benefit.
+Use `exec` only for non-interactive commands that reliably complete in a few seconds: listing files, running a quick API call, checking a status, or a simple script. Even if you need to run several of these in sequence or parallel, stick with `exec` — launching them as background jobs adds overhead for no benefit.
 
 **Rule of thumb:** if the command takes under ~5 seconds, use `exec`. Always.
+
+Do **not** use `exec` for package installation (`npm`, `npx`, `pip`, `uv`, `brew`, etc.), downloads, authentication flows, or any command that may prompt. Package managers can perform network work and routinely exceed the foreground timeout. Use `exec_bg` with explicit non-interactive flags when available. If a command truly requires user input, ask the user to run it in their terminal — shell tools have no interactive stdin.
 
 ### When to Use `exec_bg` (Background)
 
 Use `exec_bg` when the command will take noticeably long — 5+ seconds. Examples:
+- Package installation or dependency downloads
 - Image generation or media processing
 - Running a full test suite or build pipeline
 - Data processing scripts (scraping, ETL, conversions)

--- a/ragnarbot/builtin/BUILTIN_TOOLS.md
+++ b/ragnarbot/builtin/BUILTIN_TOOLS.md
@@ -25,11 +25,12 @@ List directory contents. Use to explore project structure or check what files ex
 ## Shell
 
 ### exec
-Execute a shell command. Returns stdout, stderr, and exit code.
+Execute a short, non-interactive shell command. Returns stdout, stderr, and exit code.
 - Has a timeout (commands that run too long are killed).
 - Destructive commands (rm -rf, format, dd, etc.) are blocked by safety guards (can be disabled via `tools.exec.safetyGuard: false` in config).
 - Provide `working_dir` when the command must run in a specific directory.
-- For long-running processes, warn the user about potential timeout.
+- Use `exec_bg` for package installs, downloads, builds, or anything likely to take more than a few seconds.
+- Shell tools have no interactive stdin. Use non-interactive flags or ask the user to run commands that require prompts/authentication.
 
 ## Search
 
@@ -85,7 +86,7 @@ If any of 2–4 is yes and 1 is no, call recall **before** answering — and bef
 
 ## Background Execution
 
-For tasks that take more than a few seconds — image generation, data processing, long scripts, batch operations. Do NOT use these for quick commands; use `exec` instead.
+For tasks that take more than a few seconds — package installs, downloads, image generation, data processing, long scripts, batch operations. Do NOT use these for quick commands; use `exec` instead. Commands must be non-interactive because stdin is unavailable.
 
 ### exec_bg
 Launch a shell command in the background. Returns a `job_id` immediately. The system notifies you automatically when the job finishes — no need to poll or check manually in most cases.

--- a/ragnarbot/cli/tui/__init__.py
+++ b/ragnarbot/cli/tui/__init__.py
@@ -94,7 +94,8 @@ def _onboarding_loop(console: Console) -> None:
 
         elif step == 4:
             provider_id = PROVIDERS[provider_idx]["id"]
-            model_idx = model_screen(console, provider_id)
+            auth_method = "oauth" if auth_idx == 0 else "api_key"
+            model_idx = model_screen(console, provider_id, auth_method)
             if model_idx is None:
                 step = 3
                 continue
@@ -103,7 +104,7 @@ def _onboarding_loop(console: Console) -> None:
         elif step == 5:
             provider_id = PROVIDERS[provider_idx]["id"]
             auth_method = "oauth" if auth_idx == 0 else "api_key"
-            model_id = get_models(provider_id)[model_idx]["id"]
+            model_id = get_models(provider_id, auth_method)[model_idx]["id"]
             lightning_idx = lightning_mode_screen(console, auth_method, model_id)
             if lightning_idx is None:
                 step = 4
@@ -184,7 +185,7 @@ def _onboarding_loop(console: Console) -> None:
             provider_id = PROVIDERS[provider_idx]["id"]
             provider = get_provider(provider_id)
             auth_method = "oauth" if auth_idx == 0 else "api_key"
-            models = get_models(provider_id)
+            models = get_models(provider_id, auth_method)
             model = models[model_idx]
             telegram_configured = bool(telegram_token)
 

--- a/ragnarbot/cli/tui/screens.py
+++ b/ragnarbot/cli/tui/screens.py
@@ -72,9 +72,13 @@ def token_input_screen(
     )
 
 
-def model_screen(console: Console, provider_id: str) -> int | None:
+def model_screen(
+    console: Console,
+    provider_id: str,
+    auth_method: str | None = None,
+) -> int | None:
     """Select model. Returns index or None (back)."""
-    models = get_models(provider_id)
+    models = get_models(provider_id, auth_method)
     options = [(m["name"], m["description"]) for m in models]
     provider = get_provider(provider_id)
     return select_menu(

--- a/ragnarbot/config/providers.py
+++ b/ragnarbot/config/providers.py
@@ -29,18 +29,33 @@ PROVIDERS = [
     {
         "id": "openai",
         "name": "OpenAI",
-        "description": "GPT models (GPT-5.5, GPT-5.4, GPT-5.4 Mini)",
+        "description": "GPT models (GPT-5.6 Sol, Terra, Luna, and earlier)",
         "api_key_url": "https://platform.openai.com/api-keys",
         "models": [
             {
+                "id": "openai/gpt-5.6-sol",
+                "name": "GPT-5.6 Sol",
+                "description": "Flagship — most capable GPT-5.6 model",
+            },
+            {
+                "id": "openai/gpt-5.6-terra",
+                "name": "GPT-5.6 Terra",
+                "description": "Balanced — strong lower-cost GPT-5.6 option",
+            },
+            {
+                "id": "openai/gpt-5.6-luna",
+                "name": "GPT-5.6 Luna",
+                "description": "Fastest & most affordable GPT-5.6 model",
+            },
+            {
                 "id": "openai/gpt-5.5",
                 "name": "GPT-5.5",
-                "description": "Latest flagship — best reasoning & coding",
+                "description": "Previous flagship — strong reasoning & coding",
             },
             {
                 "id": "openai/gpt-5.4",
                 "name": "GPT-5.4",
-                "description": "Previous flagship — strong reasoning & coding",
+                "description": "Earlier flagship — strong reasoning & coding",
             },
             {
                 "id": "openai/gpt-5.4-mini",

--- a/ragnarbot/config/providers.py
+++ b/ragnarbot/config/providers.py
@@ -46,6 +46,9 @@ PROVIDERS = [
                 "id": "openai/gpt-5.6-luna",
                 "name": "GPT-5.6 Luna",
                 "description": "Fastest & most affordable GPT-5.6 model",
+                # The public API supports Luna, but ChatGPT OAuth's raw
+                # Responses transport currently returns `Model not found`.
+                "oauth": False,
             },
             {
                 "id": "openai/gpt-5.5",
@@ -173,11 +176,14 @@ def get_provider(provider_id: str) -> dict | None:
     return None
 
 
-def get_models(provider_id: str) -> list[dict]:
-    """Get models for a provider."""
+def get_models(provider_id: str, auth_method: str | None = None) -> list[dict]:
+    """Get models for a provider, optionally filtered by auth method."""
     provider = get_provider(provider_id)
     if provider:
-        return provider["models"]
+        models = provider["models"]
+        if auth_method == "oauth":
+            return [model for model in models if model.get("oauth", True)]
+        return models
     return []
 
 

--- a/ragnarbot/config/validation.py
+++ b/ragnarbot/config/validation.py
@@ -29,6 +29,21 @@ def validate_model_auth(model: str, auth_method: str, creds=None) -> str | None:
                 f"OAuth is not supported for provider '{provider_name}'. "
                 f"Supported: {', '.join(sorted(OAUTH_SUPPORTED_PROVIDERS))}"
             )
+        if model == "openai/gpt-5.6":
+            return (
+                "OpenAI OAuth does not support the 'openai/gpt-5.6' alias. "
+                "Use 'openai/gpt-5.6-sol' explicitly."
+            )
+        if provider_name == "openai":
+            from ragnarbot.config.providers import get_model_info
+
+            model_info = get_model_info(model)
+            if model_info is not None and not model_info.get("oauth", True):
+                return (
+                    f"OpenAI OAuth does not support '{model}' in Ragnarbot. "
+                    "Use GPT-5.6 Sol or Terra, or use API key authentication "
+                    "for this model."
+                )
         if provider_name == "gemini":
             from ragnarbot.auth.gemini_oauth import is_authenticated
             if not is_authenticated():

--- a/ragnarbot/providers/anthropic_provider.py
+++ b/ragnarbot/providers/anthropic_provider.py
@@ -5,9 +5,16 @@ import logging
 import os
 from typing import Any
 
+import httpx
 from anthropic import APIStatusError, AsyncAnthropic
 
-from ragnarbot.providers.base import MAX_OUTPUT_TOKENS, LLMProvider, LLMResponse, ToolCallRequest
+from ragnarbot.providers.base import (
+    MAX_OUTPUT_TOKENS,
+    LLMProvider,
+    LLMResponse,
+    ToolCallRequest,
+    format_provider_exception,
+)
 from ragnarbot.providers.reasoning import resolve_reasoning
 
 # Anthropic streams every request (see chat()), so it is not bound by the SDK's
@@ -33,6 +40,8 @@ _CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claud
 # Application-level retry delays (seconds) for 529 Overloaded errors.
 # Each retry is a fresh SDK-level attempt set (the SDK itself retries twice internally).
 _OVERLOADED_RETRY_DELAYS = [0, 1, 2]
+_MAX_APP_ATTEMPTS = 1 + len(_OVERLOADED_RETRY_DELAYS)
+_OPEN_STREAM_RETRY_DELAY_SECONDS = 0.75
 
 logger = logging.getLogger(__name__)
 
@@ -130,35 +139,68 @@ class AnthropicProvider(LLMProvider):
         if reasoning.anthropic_output_config is not None:
             kwargs["output_config"] = reasoning.anthropic_output_config
 
-        last_error: Exception | None = None
-        for attempt, delay in enumerate(
-            [None, *_OVERLOADED_RETRY_DELAYS], start=1,
-        ):
-            if delay is not None:
-                if delay > 0:
-                    await asyncio.sleep(delay)
-                logger.info("Retrying after 529 Overloaded (attempt %d)", attempt)
+        overloaded_retry_index = 0
+        open_stream_retry_used = False
+        for attempt in range(1, _MAX_APP_ATTEMPTS + 1):
+            stream_opened = False
+            final_message_received = False
             try:
                 # Use streaming to avoid Anthropic SDK ValueError for max_tokens > ~21k
                 async with self.client.messages.stream(**kwargs) as stream:
+                    stream_opened = True
                     response = await stream.get_final_message()
+                    final_message_received = True
                 return self._parse_response(response)
             except APIStatusError as e:
-                if e.status_code == 529:
-                    last_error = e
+                if (
+                    e.status_code == 529
+                    and attempt < _MAX_APP_ATTEMPTS
+                    and overloaded_retry_index < len(_OVERLOADED_RETRY_DELAYS)
+                ):
+                    delay = _OVERLOADED_RETRY_DELAYS[overloaded_retry_index]
+                    overloaded_retry_index += 1
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                    logger.info(
+                        "Retrying after 529 Overloaded (attempt %d/%d)",
+                        attempt + 1,
+                        _MAX_APP_ATTEMPTS,
+                    )
                     continue
-                return LLMResponse(
-                    content=f"Error calling LLM: {e}",
-                    finish_reason="error",
-                )
+                return self._error_response(e)
+            except httpx.TransportError as e:
+                # The Anthropic SDK already retries connection failures while
+                # opening the request. It cannot retry a body-read failure once
+                # the streaming response is open, so allow exactly one such
+                # provider-level retry before any final message was received.
+                if (
+                    stream_opened
+                    and not final_message_received
+                    and not open_stream_retry_used
+                    and attempt < _MAX_APP_ATTEMPTS
+                ):
+                    open_stream_retry_used = True
+                    logger.warning(
+                        "Retrying Anthropic stream after transient read failure "
+                        "(attempt %d/%d): %s",
+                        attempt + 1,
+                        _MAX_APP_ATTEMPTS,
+                        format_provider_exception(e),
+                    )
+                    await asyncio.sleep(_OPEN_STREAM_RETRY_DELAY_SECONDS)
+                    continue
+                return self._error_response(e)
             except Exception as e:
-                return LLMResponse(
-                    content=f"Error calling LLM: {e}",
-                    finish_reason="error",
-                )
+                return self._error_response(e)
 
+        raise AssertionError("Anthropic retry loop exhausted unexpectedly")
+
+    @staticmethod
+    def _error_response(exc: Exception) -> LLMResponse:
+        detail = format_provider_exception(exc)
+        logger.error("Anthropic API call failed: %s", detail)
         return LLMResponse(
-            content=f"Error calling LLM: {last_error}",
+            content=f"Error calling LLM: {detail}",
             finish_reason="error",
         )
 

--- a/ragnarbot/providers/base.py
+++ b/ragnarbot/providers/base.py
@@ -1,5 +1,6 @@
 """Base LLM provider interface."""
 
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -10,6 +11,51 @@ DEFAULT_MAX_TOKENS = 32_000
 # models (both cap a single response at 128k tokens). Used as the default response
 # budget for those providers so long generations are not truncated early.
 MAX_OUTPUT_TOKENS = 128_000
+
+_AUTHORIZATION_VALUE_RE = re.compile(
+    r"(?i)(\bauthorization\b['\"]?\s*[:=]\s*['\"]?)"
+    r"(?:(?:bearer|basic|token)\s+)?[^\s,'\"}\]]+"
+)
+_BEARER_TOKEN_RE = re.compile(r"(?i)\bbearer\s+[^\s,'\"}\]]+")
+_SK_TOKEN_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+
+
+def _redact_provider_secrets(message: str) -> str:
+    """Redact common provider credential shapes from diagnostic text."""
+    message = _AUTHORIZATION_VALUE_RE.sub(r"\1[REDACTED]", message)
+    message = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", message)
+    return _SK_TOKEN_RE.sub("sk-[REDACTED]", message)
+
+
+def format_provider_exception(exc: BaseException) -> str:
+    """Return a compact, non-empty exception summary including useful causes.
+
+    Some transport exceptions have an empty string representation, while SDKs
+    often wrap the actionable network detail in ``__cause__``. Keep the
+    user-facing error bounded and avoid ``repr()``, which may include verbose
+    request objects.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+
+    while current is not None and len(parts) < 4 and id(current) not in seen:
+        seen.add(id(current))
+        name = type(current).__name__
+        try:
+            message = _redact_provider_secrets(" ".join(str(current).split()))
+        except Exception:
+            message = ""
+        if len(message) > 300:
+            message = f"{message[:297]}..."
+        parts.append(f"{name}: {message}" if message else name)
+
+        cause = current.__cause__
+        if cause is None and not current.__suppress_context__:
+            cause = current.__context__
+        current = cause
+
+    return " <- ".join(parts) or type(exc).__name__
 
 
 @dataclass

--- a/ragnarbot/providers/lightning.py
+++ b/ragnarbot/providers/lightning.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 LIGHTNING_SUPPORTED_MODELS = frozenset({
+    "openai/gpt-5.6",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
     "openai/gpt-5.5",
     "openai/gpt-5.4",
 })

--- a/ragnarbot/providers/openai_chatgpt_provider.py
+++ b/ragnarbot/providers/openai_chatgpt_provider.py
@@ -975,29 +975,35 @@ class OpenAIChatGPTProvider(LLMProvider):
                     elif event_type == "response.output_item.added":
                         item = event.get("item", {})
                         if item.get("type") == "function_call":
-                            item_id = item.get("id", "")
+                            item_id = item.get("id") or item.get("call_id", "")
                             pending_calls[item_id] = {
                                 "name": item.get("name", ""),
                                 "arguments": "",
+                                "call_id": item.get("call_id") or item_id,
                             }
 
                     elif event_type == "response.function_call_arguments.delta":
-                        call_id = event.get("item_id", "")
-                        if call_id in pending_calls:
-                            pending_calls[call_id]["arguments"] += event.get("delta", "")
+                        item_id = event.get("item_id", "")
+                        if item_id in pending_calls:
+                            pending_calls[item_id]["arguments"] += event.get("delta", "")
 
                     elif event_type == "response.function_call_arguments.done":
-                        call_id = event.get("item_id", "")
-                        if call_id in pending_calls:
-                            call_data = pending_calls.pop(call_id)
-                            args = call_data["arguments"]
+                        item_id = event.get("item_id", "")
+                        if item_id in pending_calls:
+                            call_data = pending_calls.pop(item_id)
+                            args = event.get("arguments", call_data["arguments"])
                             try:
                                 args = json.loads(args)
                             except (json.JSONDecodeError, ValueError):
                                 args = {"raw": args}
+                            protocol_call_id = (
+                                event.get("call_id")
+                                or call_data.get("call_id")
+                                or item_id
+                            )
                             tool_calls.append(
                                 ToolCallRequest(
-                                    id=call_id,
+                                    id=protocol_call_id,
                                     name=call_data["name"],
                                     arguments=args,
                                 )

--- a/ragnarbot/providers/openai_chatgpt_provider.py
+++ b/ragnarbot/providers/openai_chatgpt_provider.py
@@ -27,6 +27,7 @@ from ragnarbot.providers.base import (
     ToolCallHandler,
     ToolCallRequest,
     ToolRunner,
+    format_provider_exception,
 )
 from ragnarbot.providers.lightning import resolve_lightning
 from ragnarbot.providers.reasoning import resolve_reasoning
@@ -38,6 +39,8 @@ CODEX_FAST_MAX_ATTEMPTS = 2
 CODEX_FAST_RETRY_DELAY_SECONDS = 0.75
 CODEX_FAST_INITIAL_EVENT_TIMEOUT_SECONDS = 30.0
 CODEX_FAST_EVENT_POLL_INTERVAL_SECONDS = 0.25
+OPENAI_RAW_MAX_ATTEMPTS = 2
+OPENAI_RAW_RETRY_DELAY_SECONDS = 0.75
 CODEX_FAST_THREAD_REGISTRY = "thread_registry.json"
 CODEX_CLI_REQUIRED_NOTE = "OpenAI OAuth Lightning requires Codex CLI installed locally."
 CODEX_CLI_INSTALL_BUTTON_TEXT = "Install Codex CLI"
@@ -385,8 +388,10 @@ class OpenAIChatGPTProvider(LLMProvider):
                 account_id=account_id,
             )
         except Exception as e:
+            detail = format_provider_exception(e)
+            logger.error(f"OpenAI ChatGPT API call failed: {detail}")
             return LLMResponse(
-                content=f"Error calling OpenAI ChatGPT API: {e}",
+                content=f"Error calling OpenAI ChatGPT API: {detail}",
                 finish_reason="error",
             )
 
@@ -415,7 +420,23 @@ class OpenAIChatGPTProvider(LLMProvider):
             "originator": "ragnarbot",
             "accept": "text/event-stream",
         }
-        return await self._stream_request(request_body, headers)
+        for attempt in range(1, OPENAI_RAW_MAX_ATTEMPTS + 1):
+            try:
+                return await self._stream_request(request_body, headers)
+            except Exception as exc:
+                if (
+                    attempt >= OPENAI_RAW_MAX_ATTEMPTS
+                    or not _should_retry_openai_raw_exception(exc)
+                ):
+                    raise
+                logger.warning(
+                    "Retrying OpenAI raw transport after transient failure "
+                    f"(attempt {attempt}/{OPENAI_RAW_MAX_ATTEMPTS}): "
+                    f"{format_provider_exception(exc)}"
+                )
+                await asyncio.sleep(OPENAI_RAW_RETRY_DELAY_SECONDS)
+
+        raise AssertionError("OpenAI raw retry loop exhausted unexpectedly")
 
     async def _chat_codex_fast(
         self,
@@ -1341,6 +1362,21 @@ def _should_retry_codex_fast_response(response: LLMResponse) -> bool:
     return (
         "codex fast transport closed unexpectedly" in content
         or "codex fast transport startup timed out" in content
+    )
+
+
+def _should_retry_openai_raw_exception(exc: Exception) -> bool:
+    """Retry one raw request for network flakes or transient HTTP statuses."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status in {408, 409, 429} or status >= 500
+    return isinstance(
+        exc,
+        (
+            httpx.NetworkError,
+            httpx.TimeoutException,
+            httpx.RemoteProtocolError,
+        ),
     )
 
 

--- a/ragnarbot/providers/openai_chatgpt_provider.py
+++ b/ragnarbot/providers/openai_chatgpt_provider.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from ragnarbot.agent.processes import isolated_process_kwargs, terminate_process_tree
 from ragnarbot.providers.base import (
     ConsumedSteeringMessage,
     ExecutedToolCall,
@@ -45,6 +46,7 @@ CODEX_FAST_THREAD_REGISTRY = "thread_registry.json"
 CODEX_CLI_REQUIRED_NOTE = "OpenAI OAuth Lightning requires Codex CLI installed locally."
 CODEX_CLI_INSTALL_BUTTON_TEXT = "Install Codex CLI"
 CODEX_CLI_MANUAL_INSTALL = "npm install -g @openai/codex"
+CODEX_CLI_INSTALL_TIMEOUT_SECONDS = 900
 _DEFAULT_CODEX_CLI_PATHS = (
     "/opt/homebrew/bin/codex",
     "/usr/local/bin/codex",
@@ -1370,10 +1372,28 @@ async def install_codex_cli() -> tuple[bool, str]:
     command, display = install
     proc = await asyncio.create_subprocess_exec(
         *command,
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        **isolated_process_kwargs(),
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=CODEX_CLI_INSTALL_TIMEOUT_SECONDS,
+        )
+    except asyncio.CancelledError:
+        await terminate_process_tree(proc)
+        raise
+    except asyncio.TimeoutError:
+        await terminate_process_tree(proc)
+        return (
+            False,
+            f"Installation timed out after {CODEX_CLI_INSTALL_TIMEOUT_SECONDS} seconds. "
+            f"Run manually: {display}",
+        )
+    except Exception as exc:
+        await terminate_process_tree(proc)
+        return False, f"Installation failed: {exc}. Run manually: {display}"
     if proc.returncode == 0:
         if is_codex_cli_available():
             return True, display

--- a/ragnarbot/providers/openai_chatgpt_provider.py
+++ b/ragnarbot/providers/openai_chatgpt_provider.py
@@ -69,6 +69,14 @@ class _JSONRPCError(RuntimeError):
         self.data = data
 
 
+class OpenAIResponseEventError(RuntimeError):
+    """A terminal Responses API event reported a failed response."""
+
+
+class OpenAIIncompleteStreamError(RuntimeError):
+    """A raw Responses API stream ended without a terminal response event."""
+
+
 class _CodexAppServerProcess:
     """Small JSON-RPC client for `codex app-server --listen stdio://`."""
 
@@ -926,6 +934,9 @@ class OpenAIChatGPTProvider(LLMProvider):
         tool_calls: list[ToolCallRequest] = []
         finish_reason = "stop"
         usage: dict[str, int] = {}
+        terminal_response: LLMResponse | None = None
+        completed = False
+        ended_with_done = False
 
         pending_calls: dict[str, dict] = {}
 
@@ -944,6 +955,7 @@ class OpenAIChatGPTProvider(LLMProvider):
 
                     raw = line[len("data: "):]
                     if raw.strip() == "[DONE]":
+                        ended_with_done = True
                         break
 
                     try:
@@ -991,13 +1003,60 @@ class OpenAIChatGPTProvider(LLMProvider):
 
                     elif event_type == "response.completed":
                         response = event.get("response", {})
-                        resp_usage = response.get("usage", {})
-                        if resp_usage:
-                            usage = {
-                                "prompt_tokens": resp_usage.get("input_tokens", 0),
-                                "completion_tokens": resp_usage.get("output_tokens", 0),
-                                "total_tokens": resp_usage.get("total_tokens", 0),
-                            }
+                        if pending_calls:
+                            raise OpenAIIncompleteStreamError(
+                                "OpenAI response.completed arrived with incomplete "
+                                "function-call arguments"
+                            )
+                        usage = _extract_openai_response_usage(response)
+                        completed = True
+                        break
+
+                    elif event_type == "response.failed":
+                        response = event.get("response", {})
+                        terminal_response = _openai_event_error_response(
+                            event_type,
+                            response,
+                        )
+                        break
+
+                    elif event_type == "response.incomplete":
+                        response = event.get("response", {})
+                        response_usage = _extract_openai_response_usage(response)
+                        reason = _openai_incomplete_reason(response)
+                        partial_text = "".join(text_parts)
+                        if reason == "max_output_tokens" and partial_text.strip():
+                            # Preserve useful partial prose, but never surface
+                            # tool calls from a truncated response.
+                            terminal_response = LLMResponse(
+                                content=partial_text,
+                                finish_reason="length",
+                                usage=response_usage,
+                            )
+                        else:
+                            terminal_response = _openai_event_error_response(
+                                event_type,
+                                response,
+                            )
+                        break
+
+        if terminal_response is not None:
+            # Failed/incomplete responses must not leak buffered tool calls to
+            # the agent loop. Only max_output_tokens preserves partial prose.
+            return terminal_response
+
+        if not completed:
+            ending = "[DONE]" if ended_with_done else "EOF"
+            buffered: list[str] = []
+            if text_parts:
+                buffered.append("partial text")
+            if tool_calls or pending_calls:
+                buffered.append("partial tool data")
+            discarded = f"; discarded {', '.join(buffered)}" if buffered else ""
+            raise OpenAIIncompleteStreamError(
+                "OpenAI raw stream ended without response.completed, "
+                f"response.failed, or response.incomplete ({ending}{discarded})"
+            )
 
         if tool_calls:
             finish_reason = "tool_calls"
@@ -1367,6 +1426,8 @@ def _should_retry_codex_fast_response(response: LLMResponse) -> bool:
 
 def _should_retry_openai_raw_exception(exc: Exception) -> bool:
     """Retry one raw request for network flakes or transient HTTP statuses."""
+    if isinstance(exc, OpenAIIncompleteStreamError):
+        return True
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
         return status in {408, 409, 429} or status >= 500
@@ -1377,6 +1438,63 @@ def _should_retry_openai_raw_exception(exc: Exception) -> bool:
             httpx.TimeoutException,
             httpx.RemoteProtocolError,
         ),
+    )
+
+
+def _extract_openai_response_usage(response: Any) -> dict[str, int]:
+    """Extract normalized token usage from a terminal Responses API event."""
+    if not isinstance(response, dict):
+        return {}
+    raw_usage = response.get("usage")
+    if not isinstance(raw_usage, dict) or not raw_usage:
+        return {}
+    return {
+        "prompt_tokens": raw_usage.get("input_tokens", 0),
+        "completion_tokens": raw_usage.get("output_tokens", 0),
+        "total_tokens": raw_usage.get("total_tokens", 0),
+    }
+
+
+def _openai_incomplete_reason(response: Any) -> str | None:
+    """Return the documented incomplete reason when present."""
+    if not isinstance(response, dict):
+        return None
+    details = response.get("incomplete_details")
+    if not isinstance(details, dict):
+        return None
+    reason = details.get("reason")
+    return str(reason).strip() if reason is not None else None
+
+
+def _openai_event_error_response(
+    event_type: str,
+    response: Any,
+) -> LLMResponse:
+    """Build a safe error response from failed or incomplete terminal events."""
+    details: list[str] = []
+    if isinstance(response, dict):
+        if event_type == "response.failed":
+            error = response.get("error")
+            if isinstance(error, dict):
+                for key in ("code", "message"):
+                    value = error.get(key)
+                    if value is not None and str(value).strip():
+                        details.append(f"{key}={value}")
+            elif error is not None and str(error).strip():
+                details.append(str(error))
+        else:
+            reason = _openai_incomplete_reason(response)
+            if reason:
+                details.append(f"reason={reason}")
+
+    suffix = "; ".join(details) if details else "no error details"
+    detail = format_provider_exception(
+        OpenAIResponseEventError(f"{event_type}: {suffix}")
+    )
+    return LLMResponse(
+        content=f"Error calling OpenAI ChatGPT API: {detail}",
+        finish_reason="error",
+        usage=_extract_openai_response_usage(response),
     )
 
 

--- a/ragnarbot/providers/reasoning.py
+++ b/ragnarbot/providers/reasoning.py
@@ -15,6 +15,13 @@ SUPPORTED_REASONING_LEVELS: tuple[ReasoningLevel, ...] = (
     "max",
 )
 
+GPT_5_6_MODELS = frozenset({
+    "openai/gpt-5.6",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
+})
+
 
 @dataclass(frozen=True)
 class ReasoningResolution:
@@ -44,6 +51,8 @@ def resolve_reasoning(model: str, reasoning_level: str | None) -> ReasoningResol
     stored_level = normalize_reasoning_level(reasoning_level)
     normalized_model = _normalize_model_id(model)
 
+    if normalized_model in GPT_5_6_MODELS:
+        return _resolve_openai_56(normalized_model, stored_level)
     if normalized_model in {
         "openai/gpt-5.5",
         "openai/gpt-5.4",
@@ -85,6 +94,26 @@ def _normalize_model_id(model: str) -> str:
     if model.startswith("gemini-"):
         return f"gemini/{model}"
     return model
+
+
+def _resolve_openai_56(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:
+    """Map the unified levels to the full GPT-5.6 reasoning-effort range."""
+    effort_map = {
+        "off": "none",
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "ultra": "xhigh",
+        "max": "max",
+    }
+    effort = effort_map[stored_level]
+    return ReasoningResolution(
+        model=model,
+        stored_level=stored_level,
+        effective_level=stored_level,
+        reasoning_effort=effort,
+        openai_reasoning={"effort": effort},
+    )
 
 
 def _resolve_openai_flagship(model: str, stored_level: ReasoningLevel) -> ReasoningResolution:

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from anthropic import APIStatusError
+from anthropic import APIConnectionError, APIStatusError
 
 from ragnarbot.providers.anthropic_provider import (
     AnthropicProvider,
@@ -347,6 +347,13 @@ def _make_overloaded_error() -> APIStatusError:
     )
 
 
+def _make_connection_error(detail: str = "DNS lookup failed") -> APIConnectionError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    error = APIConnectionError(request=request)
+    error.__cause__ = httpx.ConnectError(detail, request=request)
+    return error
+
+
 def _make_success_stream(text="Hello"):
     block = MagicMock()
     block.type = "text"
@@ -447,3 +454,110 @@ class TestOverloadedRetry:
         assert resp.finish_reason == "error"
         assert "some other error" in (resp.content or "")
         assert call_count == 1
+
+
+class TestConnectionDiagnosticsAndRetry:
+    @pytest.mark.asyncio
+    async def test_sdk_connection_error_is_not_retried_and_includes_cause(self):
+        provider = _make_provider_with_mock_client()
+        provider.client.messages.stream = MagicMock(
+            side_effect=_make_connection_error(),
+        )
+
+        resp = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-opus-4-6",
+        )
+
+        assert resp.finish_reason == "error"
+        assert "APIConnectionError: Connection error." in (resp.content or "")
+        assert "ConnectError: DNS lookup failed" in (resp.content or "")
+        assert provider.client.messages.stream.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_connection_logs_never_include_oauth_token_or_traceback(self, caplog):
+        token = "sk-ant-oat01-sentinel-secret-token"
+        provider = _make_provider_with_mock_client()
+        provider.oauth_token = token
+        request = httpx.Request(
+            "POST",
+            "https://api.anthropic.com/v1/messages",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        error = APIConnectionError(request=request)
+        error.__cause__ = httpx.ConnectError(
+            f"Authorization: Bearer {token}",
+            request=request,
+        )
+        provider.client.messages.stream = MagicMock(side_effect=error)
+
+        with caplog.at_level("WARNING", logger="ragnarbot.providers.anthropic_provider"):
+            resp = await provider.chat(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-6",
+            )
+
+        assert token not in caplog.text
+        assert token not in (resp.content or "")
+        assert "[REDACTED]" in caplog.text
+        assert all(record.exc_info is None for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_open_stream_read_error_retries_once_then_succeeds(self):
+        provider = _make_provider_with_mock_client()
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+
+        failed_stream = AsyncMock()
+        failed_stream.__aenter__ = AsyncMock(return_value=failed_stream)
+        failed_stream.__aexit__ = AsyncMock(return_value=False)
+        failed_stream.get_final_message = AsyncMock(
+            side_effect=httpx.ReadError("", request=request),
+        )
+        provider.client.messages.stream = MagicMock(
+            side_effect=[failed_stream, _make_success_stream()],
+        )
+
+        with patch(
+            "ragnarbot.providers.anthropic_provider.asyncio.sleep",
+            AsyncMock(),
+        ) as sleep:
+            resp = await provider.chat(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-6",
+            )
+
+        assert resp.finish_reason == "stop"
+        assert resp.content == "Hello"
+        assert provider.client.messages.stream.call_count == 2
+        sleep.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_open_stream_read_error_retries_only_once_and_has_type(self):
+        provider = _make_provider_with_mock_client()
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+
+        def failed_stream():
+            stream = AsyncMock()
+            stream.__aenter__ = AsyncMock(return_value=stream)
+            stream.__aexit__ = AsyncMock(return_value=False)
+            stream.get_final_message = AsyncMock(
+                side_effect=httpx.ReadError("", request=request),
+            )
+            return stream
+
+        provider.client.messages.stream = MagicMock(
+            side_effect=[failed_stream(), failed_stream()],
+        )
+
+        with patch(
+            "ragnarbot.providers.anthropic_provider.asyncio.sleep",
+            AsyncMock(),
+        ):
+            resp = await provider.chat(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-6",
+            )
+
+        assert resp.finish_reason == "error"
+        assert resp.content == "Error calling LLM: ReadError"
+        assert provider.client.messages.stream.call_count == 2

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -301,6 +301,25 @@ class TestBackgroundProcessManager:
         finally:
             _force_kill(pid)
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX shell redirection regression")
+    @pytest.mark.asyncio
+    async def test_runtime_timeout_includes_wait_after_streams_close(self, monkeypatch):
+        deadline = 0.25
+        monkeypatch.setattr(background_module, "MAX_RUNTIME", deadline)
+        mgr, bus = _make_manager()
+        started = time.monotonic()
+        result = await mgr.spawn("exec 1>&- 2>&-; sleep 30", label="closed-streams")
+        job_id = _extract_job_id(result)
+        job = mgr._jobs[job_id]
+
+        await asyncio.wait_for(job.task, timeout=2)
+        elapsed = time.monotonic() - started
+
+        assert deadline * 0.75 <= elapsed < 1.5
+        assert job.status == JobState.killed
+        announcement = bus.publish_inbound.await_args.args[0]
+        assert "TIMED OUT" in announcement.content
+
     @pytest.mark.asyncio
     async def test_output_on_running_job(self):
         mgr, bus = _make_manager()

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,13 +1,18 @@
 """Tests for background process manager and tools."""
 
 import asyncio
+import os
 import re
+import shlex
+import signal
+import sys
 import time
 from collections import deque
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import ragnarbot.agent.background as background_module
 from ragnarbot.agent.background import (
     AUTO_DISMISS_SECONDS,
     MAX_CONCURRENT,
@@ -24,6 +29,53 @@ from ragnarbot.agent.tools.background import (
     OutputTool,
     PollTool,
 )
+
+
+def _descendant_command(pid_path, sleep_seconds: int = 30) -> str:
+    code = (
+        "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        f"time.sleep({sleep_seconds})"
+    )
+    child = (
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)} "
+        f"{shlex.quote(str(pid_path))}"
+    )
+    return f"{child} & wait"
+
+
+async def _wait_for_file(path, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not path.exists():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"Timed out waiting for {path}")
+        await asyncio.sleep(0.02)
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_for_pid_exit(pid: int, timeout: float = 2.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _pid_exists(pid):
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.02)
+    return True
+
+
+def _force_kill(pid: int | None) -> None:
+    if pid is None or not _pid_exists(pid):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -203,6 +255,51 @@ class TestBackgroundProcessManager:
         kill_result = await mgr.kill(job_id)
         assert "killed" in kill_result.lower()
         await asyncio.sleep(0.2)  # let cleanup settle
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+    @pytest.mark.asyncio
+    async def test_kill_terminates_descendant_and_finishes_runner(self, tmp_path):
+        mgr, bus = _make_manager()
+        pid_path = tmp_path / "background-child.pid"
+        pid = None
+        result = await mgr.spawn(_descendant_command(pid_path), label="tree")
+        job_id = _extract_job_id(result)
+        job = mgr._jobs[job_id]
+        try:
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+
+            kill_result = await asyncio.wait_for(mgr.kill(job_id), timeout=4)
+
+            assert "killed" in kill_result.lower()
+            assert job.status == JobState.killed
+            assert job.task.done()
+            assert await _wait_for_pid_exit(pid), "kill left a background child alive"
+            bus.publish_inbound.assert_not_awaited()
+        finally:
+            _force_kill(pid)
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+    @pytest.mark.asyncio
+    async def test_runtime_timeout_terminates_descendant(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(background_module, "MAX_RUNTIME", 0.5)
+        mgr, bus = _make_manager()
+        pid_path = tmp_path / "timed-background-child.pid"
+        pid = None
+        result = await mgr.spawn(_descendant_command(pid_path), label="tree-timeout")
+        job_id = _extract_job_id(result)
+        job = mgr._jobs[job_id]
+        try:
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+            await asyncio.wait_for(job.task, timeout=4)
+
+            assert job.status == JobState.killed
+            assert await _wait_for_pid_exit(pid), "runtime timeout left a child alive"
+            announcement = bus.publish_inbound.await_args.args[0]
+            assert "TIMED OUT" in announcement.content
+        finally:
+            _force_kill(pid)
 
     @pytest.mark.asyncio
     async def test_output_on_running_job(self):

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,6 +1,8 @@
 """Tests for background process manager and tools."""
 
 import asyncio
+import contextlib
+import gc
 import os
 import re
 import shlex
@@ -34,6 +36,20 @@ from ragnarbot.agent.tools.background import (
 def _descendant_command(pid_path, sleep_seconds: int = 30) -> str:
     code = (
         "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        f"time.sleep({sleep_seconds})"
+    )
+    child = (
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)} "
+        f"{shlex.quote(str(pid_path))}"
+    )
+    return f"{child} & wait"
+
+
+def _sigterm_resistant_descendant_command(pid_path, sleep_seconds: int = 30) -> str:
+    code = (
+        "import os, pathlib, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
         "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
         f"time.sleep({sleep_seconds})"
     )
@@ -319,6 +335,94 @@ class TestBackgroundProcessManager:
         assert job.status == JobState.killed
         announcement = bus.publish_inbound.await_args.args[0]
         assert "TIMED OUT" in announcement.content
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+    @pytest.mark.asyncio
+    async def test_explicit_kill_wins_race_with_runtime_timeout(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(background_module, "MAX_RUNTIME", 0.3)
+        real_terminate = background_module.terminate_process_tree
+        first_cleanup_started = asyncio.Event()
+        timeout_cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        cleanup_calls = 0
+
+        async def controlled_terminate(process):
+            nonlocal cleanup_calls
+            cleanup_calls += 1
+            if cleanup_calls == 1:
+                first_cleanup_started.set()
+            else:
+                timeout_cleanup_started.set()
+            await release_cleanup.wait()
+            await real_terminate(process, grace_period=0.05)
+
+        monkeypatch.setattr(background_module, "terminate_process_tree", controlled_terminate)
+        mgr, bus = _make_manager()
+        pid_path = tmp_path / "kill-timeout-race.pid"
+        pid = None
+        kill_task = None
+        result = await mgr.spawn(
+            _sigterm_resistant_descendant_command(pid_path), label="kill-timeout-race",
+        )
+        job_id = _extract_job_id(result)
+        job = mgr._jobs[job_id]
+        try:
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+            kill_task = asyncio.create_task(mgr.kill(job_id))
+            await asyncio.wait_for(first_cleanup_started.wait(), timeout=1)
+            await asyncio.wait_for(timeout_cleanup_started.wait(), timeout=1)
+            release_cleanup.set()
+
+            kill_result = await asyncio.wait_for(kill_task, timeout=2)
+
+            assert "killed" in kill_result.lower()
+            assert job.status == JobState.killed
+            assert job.task.done()
+            assert await _wait_for_pid_exit(pid)
+            bus.publish_inbound.assert_not_awaited()
+        finally:
+            release_cleanup.set()
+            if kill_task is not None and not kill_task.done():
+                kill_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await kill_task
+            _force_kill(pid)
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+    @pytest.mark.asyncio
+    async def test_direct_runner_cancellation_retrieves_lifecycle_future(self, tmp_path):
+        mgr, bus = _make_manager()
+        pid_path = tmp_path / "direct-cancel-child.pid"
+        pid = None
+        contexts = []
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: contexts.append(context))
+        result = await mgr.spawn(_descendant_command(pid_path), label="direct-cancel")
+        job_id = _extract_job_id(result)
+        job = mgr._jobs[job_id]
+        try:
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+            job.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await job.task
+
+            for _ in range(3):
+                gc.collect()
+                await asyncio.sleep(0)
+
+            assert job.status == JobState.killed
+            assert await _wait_for_pid_exit(pid)
+            bus.publish_inbound.assert_not_awaited()
+            assert not any(
+                "exception was never retrieved" in context.get("message", "").lower()
+                for context in contexts
+            )
+        finally:
+            loop.set_exception_handler(previous_handler)
+            _force_kill(pid)
 
     @pytest.mark.asyncio
     async def test_output_on_running_job(self):

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -1,11 +1,13 @@
 """Tests for profile-local browser storage."""
 
+import asyncio
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import ragnarbot.agent.tools.browser as browser_module
 from ragnarbot.agent.tools.browser import BrowserSession, BrowserSessionManager
 
 
@@ -79,3 +81,58 @@ async def test_screenshot_uses_profile_local_screenshot_dir(tmp_path):
     assert len(saved_files) == 1
     assert saved_files[0].name.startswith("abc12345_")
     assert str(instance.browser_screenshots_path) in result[1]["text"]
+
+
+def _manager_with_missing_chromium(tmp_path):
+    instance = SimpleNamespace(
+        browser_profile_path=tmp_path / "browser-profile",
+        browser_screenshots_path=tmp_path / "browser-screenshots",
+    )
+    with patch("ragnarbot.agent.tools.browser.ensure_instance_root", return_value=instance):
+        manager = BrowserSessionManager(config=_config())
+    manager._playwright = SimpleNamespace(
+        chromium=SimpleNamespace(executable_path=str(tmp_path / "missing-chromium")),
+    )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_chromium_installer_drains_output_with_communicate(tmp_path):
+    manager = _manager_with_missing_chromium(tmp_path)
+    proc = SimpleNamespace(
+        pid=1234,
+        returncode=0,
+        communicate=AsyncMock(return_value=(b"installed", b"")),
+    )
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        await manager._install_chromium_if_needed()
+
+    proc.communicate.assert_awaited_once()
+    assert manager._chromium_installed is True
+
+
+@pytest.mark.asyncio
+async def test_chromium_installer_timeout_cleans_process_tree(tmp_path, monkeypatch):
+    manager = _manager_with_missing_chromium(tmp_path)
+
+    async def _hang():
+        await asyncio.Event().wait()
+
+    proc = SimpleNamespace(
+        pid=1234,
+        returncode=None,
+        communicate=AsyncMock(side_effect=_hang),
+    )
+    terminate = AsyncMock()
+    monkeypatch.setattr(browser_module, "BROWSER_INSTALL_TIMEOUT_SECONDS", 0.01)
+
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        patch("ragnarbot.agent.tools.browser.terminate_process_tree", terminate),
+    ):
+        with pytest.raises(RuntimeError, match="timed out"):
+            await manager._install_chromium_if_needed()
+
+    terminate.assert_awaited_once_with(proc)
+    assert manager._chromium_installed is False

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,39 @@
+"""Tests for model/auth compatibility validation."""
+
+from unittest.mock import patch
+
+import pytest
+
+from ragnarbot.auth.credentials import Credentials
+from ragnarbot.config.validation import validate_model_auth
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("openai/gpt-5.6", "gpt-5.6-sol"),
+        ("openai/gpt-5.6-luna", "Sol or Terra"),
+    ],
+)
+def test_openai_oauth_rejects_models_unsupported_by_chatgpt_transport(model, expected):
+    with patch("ragnarbot.auth.openai_oauth.is_authenticated", return_value=True):
+        error = validate_model_auth(model, "oauth", Credentials())
+
+    assert error is not None
+    assert expected in error
+
+
+def test_openai_oauth_accepts_sol():
+    with patch("ragnarbot.auth.openai_oauth.is_authenticated", return_value=True):
+        assert validate_model_auth(
+            "openai/gpt-5.6-sol", "oauth", Credentials(),
+        ) is None
+
+
+def test_openai_api_key_still_accepts_luna():
+    credentials = Credentials()
+    credentials.providers.openai.api_key = "sk-test"
+
+    assert validate_model_auth(
+        "openai/gpt-5.6-luna", "api_key", credentials,
+    ) is None

--- a/tests/test_fallback_unification.py
+++ b/tests/test_fallback_unification.py
@@ -150,11 +150,16 @@ class TestSubagentChatFn:
         )
 
         response, used_fallback, error = await mgr._chat_fn(
-            None, messages=[], tools=[], model="test/model",
+            None,
+            force_fallback=True,
+            messages=[],
+            tools=[],
+            model="test/model",
         )
         assert response.content == "result"
         assert used_fallback is False
         mgr.provider.chat.assert_called_once()
+        assert "force_fallback" not in mgr.provider.chat.await_args.kwargs
 
     def _make_agent_task(self, task_id="test-id", task="do something",
                          label="test label", channel="test", chat_id="1"):
@@ -385,6 +390,173 @@ async def test_fallback_stays_sticky_for_entire_interaction(tmp_path, system_mes
 
     assert next_response is not None
     assert next_response.content == "PRIMARY NEXT INTERACTION"
+    assert primary.chat.await_count == 2
+    assert fallback.chat.await_count == 2
+    assert agent._fallback_state.consecutive_failures == 0
+
+
+def _make_isolated_fallback_agent(tmp_path, *, real_subagents=False):
+    primary_model = "openai/gpt-5.6-sol"
+    fallback_model = "anthropic/claude-opus-4-8"
+
+    primary = MagicMock()
+    primary.get_default_model.return_value = primary_model
+    primary.chat = AsyncMock(side_effect=[
+        LLMResponse(content="primary timeout", finish_reason="error"),
+        LLMResponse(content="PRIMARY NEXT RUN"),
+    ])
+
+    fallback = MagicMock()
+    fallback.chat = AsyncMock(side_effect=[
+        LLMResponse(
+            content="running tool",
+            tool_calls=[ToolCallRequest(
+                id="tool-1",
+                name="list_dir",
+                arguments={"path": "."},
+            )],
+            finish_reason="tool_calls",
+        ),
+        LLMResponse(content="FALLBACK FINAL"),
+    ])
+    provider_factory = MagicMock(return_value=fallback)
+
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_inbound = AsyncMock()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    kwargs = {
+        "bus": bus,
+        "provider": primary,
+        "workspace": workspace,
+        "model": primary_model,
+        "exec_config": ExecToolConfig(),
+        "fallback_model": fallback_model,
+        "fallback_config": FallbackConfig(model=fallback_model),
+        "provider_factory": provider_factory,
+    }
+    if real_subagents:
+        agent = AgentLoop(**kwargs)
+    else:
+        with patch("ragnarbot.agent.loop.SubagentManager"):
+            agent = AgentLoop(**kwargs)
+
+    agent._fallback_state = FallbackState()
+    agent._fallback_state.save = MagicMock()
+    return agent, primary, fallback, provider_factory, fallback_model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loop_kind", ["cron", "hook", "heartbeat"])
+async def test_isolated_tool_loops_keep_fallback_sticky_per_run(tmp_path, loop_kind):
+    agent, primary, fallback, provider_factory, fallback_model = (
+        _make_isolated_fallback_agent(tmp_path)
+    )
+    agent.last_active_chat = ("telegram", "123")
+
+    async def run_once(sequence: int):
+        if loop_kind == "cron":
+            return await agent.process_cron_isolated(
+                job_name=f"job-{sequence}",
+                message="inspect workspace",
+                schedule_desc="manual test",
+                channel="telegram",
+                chat_id="123",
+            )
+        if loop_kind == "hook":
+            return await agent.process_hook_isolated(
+                hook_name=f"hook-{sequence}",
+                instructions="inspect workspace",
+                payload="{}",
+                mode="alert",
+                channel="telegram",
+                chat_id="123",
+            )
+        return await agent.process_heartbeat()
+
+    first_result = await run_once(1)
+
+    if loop_kind == "heartbeat":
+        assert first_result == (None, "telegram", "123")
+    else:
+        assert first_result == "FALLBACK FINAL"
+    assert primary.chat.await_count == 1
+    assert fallback.chat.await_count == 2
+    provider_factory.assert_called_once_with(fallback_model, "api_key")
+    assert fallback.chat.await_args_list[1].kwargs["model"] == fallback_model
+    assert agent._fallback_state.consecutive_failures == 1
+
+    second_result = await run_once(2)
+
+    if loop_kind == "heartbeat":
+        assert second_result == (None, "telegram", "123")
+    else:
+        assert second_result == "PRIMARY NEXT RUN"
+    assert primary.chat.await_count == 2
+    assert fallback.chat.await_count == 2
+    assert agent._fallback_state.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_loop_keeps_fallback_sticky_per_run(tmp_path):
+    import asyncio
+
+    from ragnarbot.agent.subagent import AgentTask, AgentTaskStatus
+    from ragnarbot.agent.tools.deliver_result import DeliverResultTool
+    from ragnarbot.agent.tools.filesystem import ListDirTool
+    from ragnarbot.agent.tools.registry import ToolRegistry
+
+    agent, primary, fallback, provider_factory, fallback_model = (
+        _make_isolated_fallback_agent(tmp_path, real_subagents=True)
+    )
+
+    tools = ToolRegistry()
+    tools.register(ListDirTool(workspace=agent.workspace))
+    deliver_tool = DeliverResultTool()
+    tools.register(deliver_tool)
+
+    def make_task(task_id: str) -> AgentTask:
+        return AgentTask(
+            id=task_id,
+            label="sticky fallback",
+            agent_name=None,
+            task="inspect workspace",
+            status=AgentTaskStatus.running,
+            messages=[],
+            stop_event=asyncio.Event(),
+            origin={"channel": "telegram", "chat_id": "123"},
+        )
+
+    first_task = make_task("first")
+    await agent.subagents._run_agent(
+        first_task,
+        definition=None,
+        model=agent.model,
+        tools=tools,
+        deliver_tool=deliver_tool,
+    )
+
+    assert first_task.status == AgentTaskStatus.completed
+    assert first_task.result == "FALLBACK FINAL"
+    assert primary.chat.await_count == 1
+    assert fallback.chat.await_count == 2
+    provider_factory.assert_called_once_with(fallback_model, "api_key")
+    assert fallback.chat.await_args_list[1].kwargs["model"] == fallback_model
+    assert agent._fallback_state.consecutive_failures == 1
+
+    second_task = make_task("second")
+    await agent.subagents._run_agent(
+        second_task,
+        definition=None,
+        model=agent.model,
+        tools=tools,
+        deliver_tool=deliver_tool,
+    )
+
+    assert second_task.status == AgentTaskStatus.completed
+    assert second_task.result == "PRIMARY NEXT RUN"
     assert primary.chat.await_count == 2
     assert fallback.chat.await_count == 2
     assert agent._fallback_state.consecutive_failures == 0

--- a/tests/test_fallback_unification.py
+++ b/tests/test_fallback_unification.py
@@ -1,17 +1,17 @@
 """Tests for unified fallback support across all LLM call sites."""
 
-import asyncio
-from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ragnarbot.agent.compactor import Compactor
 from ragnarbot.agent.cache import CacheManager
+from ragnarbot.agent.compactor import Compactor
 from ragnarbot.agent.fallback import FallbackState
+from ragnarbot.agent.loop import AgentLoop
 from ragnarbot.agent.subagent import SubagentManager
-from ragnarbot.providers.base import LLMResponse
-
+from ragnarbot.bus.events import InboundMessage
+from ragnarbot.config.schema import ExecToolConfig, FallbackConfig
+from ragnarbot.providers.base import LLMResponse, ToolCallRequest
 
 # ── Compactor chat_fn tests ──────────────────────────────────────
 
@@ -159,6 +159,7 @@ class TestSubagentChatFn:
     def _make_agent_task(self, task_id="test-id", task="do something",
                          label="test label", channel="test", chat_id="1"):
         import asyncio
+
         from ragnarbot.agent.subagent import AgentTask, AgentTaskStatus
         return AgentTask(
             id=task_id,
@@ -282,3 +283,108 @@ class TestRecordFallbackBatch:
         was_fb = state.record_primary_success()
         assert was_fb is False
         assert state.consecutive_failures == 0
+
+
+# ── Foreground/system interaction stickiness ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("system_message", [False, True])
+async def test_fallback_stays_sticky_for_entire_interaction(tmp_path, system_message):
+    """A fallback tool call must not hand the final answer back to primary."""
+    primary_model = "openai/gpt-5.6-sol"
+    fallback_model = "anthropic/claude-opus-4-8"
+
+    primary = MagicMock()
+    primary.get_default_model.return_value = primary_model
+    primary.chat = AsyncMock(side_effect=[
+        LLMResponse(content="primary timeout", finish_reason="error"),
+        LLMResponse(content="PRIMARY NEXT INTERACTION"),
+    ])
+
+    fallback = MagicMock()
+    fallback.chat = AsyncMock(side_effect=[
+        LLMResponse(
+            content="running tool",
+            tool_calls=[ToolCallRequest(
+                id="tool-1",
+                name="exec",
+                arguments={"command": "echo ok"},
+            )],
+            finish_reason="tool_calls",
+        ),
+        LLMResponse(content="FALLBACK FINAL"),
+    ])
+    provider_factory = MagicMock(return_value=fallback)
+
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_inbound = AsyncMock()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    with patch("ragnarbot.agent.loop.SubagentManager"):
+        agent = AgentLoop(
+            bus=bus,
+            provider=primary,
+            workspace=workspace,
+            model=primary_model,
+            exec_config=ExecToolConfig(),
+            fallback_model=fallback_model,
+            fallback_config=FallbackConfig(model=fallback_model),
+            provider_factory=provider_factory,
+        )
+
+    agent._fallback_state = FallbackState()
+    agent._fallback_state.save = MagicMock()
+    agent._execute_tool_with_tracking = AsyncMock(return_value="tool ok")
+    agent.index.start_chat_jobs = AsyncMock()
+
+    if system_message:
+        message = InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="telegram:123",
+            content="system result",
+        )
+        response = await agent._process_system_message(message)
+    else:
+        message = InboundMessage(
+            channel="telegram",
+            sender_id="user-1",
+            chat_id="123",
+            content="run a tool",
+        )
+        response = await agent._process_batch([message])
+
+    assert response is not None
+    assert response.content == f"FALLBACK FINAL\n\n_⚡ fallback: {fallback_model}_"
+    assert primary.chat.await_count == 1
+    assert fallback.chat.await_count == 2
+    provider_factory.assert_called_once_with(fallback_model, "api_key")
+    assert fallback.chat.await_args_list[1].kwargs["model"] == fallback_model
+    assert agent._execute_tool_with_tracking.await_count == 1
+    assert agent._fallback_state.consecutive_failures == 1
+    agent._fallback_state.save.assert_called_once_with()
+
+    # The pin is interaction-local: the next interaction probes primary normally.
+    if system_message:
+        next_response = await agent._process_system_message(InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="telegram:123",
+            content="next system result",
+        ))
+    else:
+        next_response = await agent._process_batch([InboundMessage(
+            channel="telegram",
+            sender_id="user-1",
+            chat_id="123",
+            content="next request",
+        )])
+
+    assert next_response is not None
+    assert next_response.content == "PRIMARY NEXT INTERACTION"
+    assert primary.chat.await_count == 2
+    assert fallback.chat.await_count == 2
+    assert agent._fallback_state.consecutive_failures == 0

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -167,7 +167,7 @@ class TestOnboardingFlow:
             (Key.ENTER, ""),        # Select API Key
             *[(Key.CHAR, c) for c in "sk-openai-key"],
             (Key.ENTER, ""),        # Confirm key
-            (Key.ENTER, ""),        # Select first model (GPT-5.5)
+            (Key.ENTER, ""),        # Select first model (GPT-5.6 Sol)
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
             (Key.DOWN, ""),         # Voice: past OpenAI Transcribe
@@ -183,7 +183,7 @@ class TestOnboardingFlow:
         mock_save_config, mock_save_creds = self._run_with_keys(keys, tmp_path)
 
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "openai/gpt-5.5"
+        assert config.agents.defaults.model == "openai/gpt-5.6-sol"
         assert config.agents.defaults.auth_method == "api_key"
         assert config.agents.defaults.lightning_mode is True
 
@@ -196,7 +196,7 @@ class TestOnboardingFlow:
             (Key.DOWN, ""),         # Navigate to OpenAI
             (Key.ENTER, ""),        # Select OpenAI
             (Key.ENTER, ""),        # Select OAuth
-            (Key.ENTER, ""),        # Select first model (GPT-5.5)
+            (Key.ENTER, ""),        # Select first model (GPT-5.6 Sol)
             *ENABLE_LIGHTNING,
             (Key.ENTER, ""),        # Acknowledge Codex CLI required
         ]
@@ -224,7 +224,7 @@ class TestOnboardingFlow:
             run_onboarding(con)
 
         config = mock_save_config.call_args[0][0]
-        assert config.agents.defaults.model == "openai/gpt-5.5"
+        assert config.agents.defaults.model == "openai/gpt-5.6-sol"
         assert config.agents.defaults.auth_method == "oauth"
         assert config.agents.defaults.lightning_mode is False
         assert mock_save_creds.called
@@ -543,7 +543,7 @@ class TestVoiceTranscriptionOnboarding:
             (Key.ENTER, ""),        # Select API Key
             *[(Key.CHAR, c) for c in "sk-openai-llm"],
             (Key.ENTER, ""),        # Confirm key
-            (Key.ENTER, ""),        # Select first model (GPT-5.5)
+            (Key.ENTER, ""),        # Select first model (GPT-5.6 Sol)
             *SKIP_LIGHTNING,
             (Key.ENTER, ""),        # Skip telegram
             (Key.DOWN, ""),         # Voice: to OpenAI GPT-4o Mini Transcribe

--- a/tests/test_openai_chatgpt_provider.py
+++ b/tests/test_openai_chatgpt_provider.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import json
+import os
+import signal
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -21,6 +24,32 @@ from ragnarbot.providers.openai_chatgpt_provider import (
     get_codex_cli_install_command,
     install_codex_cli,
 )
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_for_pid_exit(pid: int, timeout: float = 2.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _pid_exists(pid):
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.02)
+    return True
+
+
+def _force_kill(pid: int | None) -> None:
+    if pid is None or not _pid_exists(pid):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 
 class _FakeSSEStream:
@@ -315,6 +344,9 @@ async def test_install_codex_cli_runs_detected_installer():
     assert ok is True
     assert detail == CODEX_CLI_MANUAL_INSTALL
     spawn.assert_awaited_once()
+    assert spawn.await_args.kwargs["stdin"] == asyncio.subprocess.DEVNULL
+    if os.name == "posix":
+        assert spawn.await_args.kwargs["start_new_session"] is True
 
 
 @pytest.mark.asyncio
@@ -338,6 +370,109 @@ async def test_install_codex_cli_reports_path_issue_after_successful_install():
     assert ok is False
     assert "still not on PATH" in detail
     assert CODEX_CLI_MANUAL_INSTALL in detail
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+@pytest.mark.asyncio
+async def test_install_codex_cli_timeout_kills_installer_descendants(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        openai_chatgpt_provider, "CODEX_CLI_INSTALL_TIMEOUT_SECONDS", 0.5,
+    )
+    pid_path = tmp_path / "codex-installer-child.pid"
+    parent_code = (
+        "import pathlib, subprocess, sys, time; "
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(30)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(30)"
+    )
+    child_pid = None
+    with (
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.is_codex_cli_available",
+            return_value=False,
+        ),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.get_codex_cli_install_command",
+            return_value=(
+                [sys.executable, "-c", parent_code, str(pid_path)],
+                CODEX_CLI_MANUAL_INSTALL,
+            ),
+        ),
+    ):
+        try:
+            ok, detail = await install_codex_cli()
+
+            child_pid = int(pid_path.read_text())
+            assert ok is False
+            assert "timed out" in detail
+            assert await _wait_for_pid_exit(child_pid), "timeout left installer child alive"
+        finally:
+            _force_kill(child_pid)
+
+
+@pytest.mark.asyncio
+async def test_install_codex_cli_cancellation_cleans_process_tree():
+    class FakeProc:
+        pid = 1234
+        returncode = None
+
+        async def communicate(self):
+            raise asyncio.CancelledError
+
+    terminate = AsyncMock()
+    proc = FakeProc()
+    with (
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.is_codex_cli_available",
+            return_value=False,
+        ),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.get_codex_cli_install_command",
+            return_value=(["installer"], "manual installer"),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.terminate_process_tree", terminate,
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await install_codex_cli()
+
+    terminate.assert_awaited_once_with(proc)
+
+
+@pytest.mark.asyncio
+async def test_install_codex_cli_error_cleans_process_tree_and_reports_manual_step():
+    class FakeProc:
+        pid = 1234
+        returncode = None
+
+        async def communicate(self):
+            raise RuntimeError("installer transport failed")
+
+    terminate = AsyncMock()
+    proc = FakeProc()
+    with (
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.is_codex_cli_available",
+            return_value=False,
+        ),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.get_codex_cli_install_command",
+            return_value=(["installer"], "manual installer"),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.terminate_process_tree", terminate,
+        ),
+    ):
+        ok, detail = await install_codex_cli()
+
+    assert ok is False
+    assert "installer transport failed" in detail
+    assert "manual installer" in detail
+    terminate.assert_awaited_once_with(proc)
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_chatgpt_provider.py
+++ b/tests/test_openai_chatgpt_provider.py
@@ -1,6 +1,7 @@
 """Tests for the OpenAI ChatGPT OAuth provider."""
 
 import asyncio
+import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -20,6 +21,56 @@ from ragnarbot.providers.openai_chatgpt_provider import (
     get_codex_cli_install_command,
     install_codex_cli,
 )
+
+
+class _FakeSSEStream:
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeAsyncClient:
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def stream(self, *args, **kwargs):
+        return _FakeSSEStream(self._lines)
+
+
+def _sse_lines(events, *, include_done=False):
+    lines = [f"data: {json.dumps(event)}" for event in events]
+    if include_done:
+        lines.append("data: [DONE]")
+    return lines
+
+
+async def _parse_raw_sse(events, *, include_done=False):
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+    client = _FakeAsyncClient(_sse_lines(events, include_done=include_done))
+    with patch(
+        "ragnarbot.providers.openai_chatgpt_provider.httpx.AsyncClient",
+        return_value=client,
+    ):
+        return await provider._stream_request({}, {})
 
 
 def test_openai_chatgpt_provider_defaults_to_gpt_5_4():
@@ -489,6 +540,231 @@ async def test_raw_transport_does_not_retry_auth_status():
     assert "HTTPStatusError" in (response.content or "")
     assert "401 Unauthorized" in (response.content or "")
     assert stream_request.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_completed_preserves_text_tools_and_usage_without_done_marker():
+    response = await _parse_raw_sse([
+        {"type": "response.output_text.delta", "delta": "Hello"},
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_1", "name": "lookup"},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"query":"Oslo"}',
+        },
+        {"type": "response.function_call_arguments.done", "item_id": "item_1"},
+        {
+            "type": "response.completed",
+            "response": {
+                "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            },
+        },
+    ])
+
+    assert response.content == "Hello"
+    assert response.finish_reason == "tool_calls"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].id == "item_1"
+    assert response.tool_calls[0].name == "lookup"
+    assert response.tool_calls[0].arguments == {"query": "Oslo"}
+    assert response.usage == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+    }
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_failed_returns_safe_error_and_discards_partial_output():
+    token = "sk-proj-sentinel-secret-token"
+    response = await _parse_raw_sse([
+        {"type": "response.output_text.delta", "delta": "partial answer"},
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_1", "name": "dangerous_tool"},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"partial":true',
+        },
+        {
+            "type": "response.failed",
+            "response": {
+                "error": {
+                    "code": "server_error",
+                    "message": f"Authorization: Bearer {token}",
+                },
+                "usage": {"input_tokens": 8, "output_tokens": 2, "total_tokens": 10},
+            },
+        },
+    ])
+
+    assert response.finish_reason == "error"
+    assert response.tool_calls == []
+    assert "response.failed" in (response.content or "")
+    assert "server_error" in (response.content or "")
+    assert "partial answer" not in (response.content or "")
+    assert token not in (response.content or "")
+    assert "[REDACTED]" in (response.content or "")
+    assert response.usage["total_tokens"] == 10
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_max_tokens_preserves_partial_text_but_drops_tools():
+    response = await _parse_raw_sse([
+        {"type": "response.output_text.delta", "delta": "useful partial answer"},
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_1", "name": "do_not_run"},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": "{}",
+        },
+        {"type": "response.function_call_arguments.done", "item_id": "item_1"},
+        {
+            "type": "response.incomplete",
+            "response": {
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "usage": {"input_tokens": 12, "output_tokens": 20, "total_tokens": 32},
+            },
+        },
+    ])
+
+    assert response.finish_reason == "length"
+    assert response.content == "useful partial answer"
+    assert response.tool_calls == []
+    assert response.usage["total_tokens"] == 32
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_max_tokens_without_text_is_error_for_fallback():
+    response = await _parse_raw_sse([
+        {"type": "response.output_text.delta", "delta": "   "},
+        {
+            "type": "response.incomplete",
+            "response": {
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        },
+    ])
+
+    assert response.finish_reason == "error"
+    assert response.tool_calls == []
+    assert "reason=max_output_tokens" in (response.content or "")
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_other_incomplete_reason_is_error_and_discards_partial_output():
+    response = await _parse_raw_sse([
+        {"type": "response.output_text.delta", "delta": "filtered partial"},
+        {
+            "type": "response.incomplete",
+            "response": {
+                "incomplete_details": {"reason": "content_filter"},
+            },
+        },
+    ])
+
+    assert response.finish_reason == "error"
+    assert response.tool_calls == []
+    assert "reason=content_filter" in (response.content or "")
+    assert "filtered partial" not in (response.content or "")
+
+
+@pytest.mark.asyncio
+async def test_raw_sse_completed_with_pending_tool_retries_then_errors_safely():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    token = "sk-proj-pending-argument-secret"
+    events = [
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_1", "name": "do_not_run"},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": f'{{"token":"{token}"',
+        },
+        {"type": "response.completed", "response": {"usage": {"total_tokens": 4}}},
+    ]
+    client = _FakeAsyncClient(_sse_lines(events))
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.httpx.AsyncClient",
+            return_value=client,
+        ) as client_constructor,
+        patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.finish_reason == "error"
+    assert response.tool_calls == []
+    assert "OpenAIIncompleteStreamError" in (response.content or "")
+    assert "incomplete function-call arguments" in (response.content or "")
+    assert token not in (response.content or "")
+    assert client_constructor.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("include_done", "ending"),
+    [(False, "EOF"), (True, "[DONE]")],
+)
+async def test_raw_sse_without_terminal_event_retries_then_errors_without_partial_data(
+    include_done,
+    ending,
+):
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    token = "sk-proj-buffered-sentinel-token"
+    events = [
+        {"type": "response.output_text.delta", "delta": f"partial {token}"},
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_1", "name": "do_not_run"},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": "{}",
+        },
+        {"type": "response.function_call_arguments.done", "item_id": "item_1"},
+    ]
+    client = _FakeAsyncClient(_sse_lines(events, include_done=include_done))
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch(
+            "ragnarbot.providers.openai_chatgpt_provider.httpx.AsyncClient",
+            return_value=client,
+        ) as client_constructor,
+        patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.finish_reason == "error"
+    assert response.tool_calls == []
+    assert "OpenAIIncompleteStreamError" in (response.content or "")
+    assert ending in (response.content or "")
+    assert token not in (response.content or "")
+    assert client_constructor.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_chatgpt_provider.py
+++ b/tests/test_openai_chatgpt_provider.py
@@ -713,6 +713,83 @@ async def test_raw_sse_completed_preserves_text_tools_and_usage_without_done_mar
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("added_call_id", "done_call_id", "expected_call_id"),
+    [
+        ("call_from_added", None, "call_from_added"),
+        (None, "call_from_done", "call_from_done"),
+    ],
+)
+async def test_raw_sse_preserves_protocol_call_id_through_tool_output_round_trip(
+    added_call_id,
+    done_call_id,
+    expected_call_id,
+):
+    added_item = {
+        "type": "function_call",
+        "id": "fc_transport_item",
+        "name": "lookup",
+    }
+    if added_call_id:
+        added_item["call_id"] = added_call_id
+    done_event = {
+        "type": "response.function_call_arguments.done",
+        "item_id": "fc_transport_item",
+    }
+    if done_call_id:
+        done_event["call_id"] = done_call_id
+
+    response = await _parse_raw_sse([
+        {"type": "response.output_item.added", "item": added_item},
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_transport_item",
+            "delta": '{"query":"Oslo"}',
+        },
+        done_event,
+        {"type": "response.completed", "response": {}},
+    ])
+
+    tool_call = response.tool_calls[0]
+    assert tool_call.id == expected_call_id
+
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+    body = provider._build_request(
+        messages=[
+            {"role": "user", "content": "Look it up"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": tool_call.id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_call.name,
+                        "arguments": tool_call.arguments,
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": "Oslo result",
+            },
+        ],
+        tools=None,
+        model="gpt-5.5",
+        reasoning_level=None,
+    )
+
+    function_call = next(item for item in body["input"] if item.get("type") == "function_call")
+    function_output = next(
+        item for item in body["input"] if item.get("type") == "function_call_output"
+    )
+    assert function_call["call_id"] == expected_call_id
+    assert function_output["call_id"] == expected_call_id
+
+
+@pytest.mark.asyncio
 async def test_raw_sse_failed_returns_safe_error_and_discards_partial_output():
     token = "sk-proj-sentinel-secret-token"
     response = await _parse_raw_sse([

--- a/tests/test_openai_chatgpt_provider.py
+++ b/tests/test_openai_chatgpt_provider.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 import ragnarbot.providers.openai_chatgpt_provider as openai_chatgpt_provider
@@ -338,6 +339,156 @@ async def test_provider_keeps_raw_path_for_non_gpt_5_4_models():
     assert response.content == "raw"
     raw.assert_awaited_once()
     fast.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_transport_retries_once_after_empty_read_error():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    request = httpx.Request("POST", openai_chatgpt_provider.RESPONSES_URL)
+    stream_request = AsyncMock(side_effect=[
+        httpx.ReadError("", request=request),
+        LLMResponse(content="ok"),
+    ])
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch.object(provider, "_stream_request", stream_request),
+        patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()) as sleep,
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.content == "ok"
+    assert stream_request.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_raw_transport_exhaustion_has_non_empty_exception_type():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    request = httpx.Request("POST", openai_chatgpt_provider.RESPONSES_URL)
+    stream_request = AsyncMock(side_effect=[
+        httpx.ReadError("", request=request),
+        httpx.ReadError("", request=request),
+    ])
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch.object(provider, "_stream_request", stream_request),
+        patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.finish_reason == "error"
+    assert response.content == "Error calling OpenAI ChatGPT API: ReadError"
+    assert stream_request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_raw_transport_logs_never_include_bearer_token_or_traceback():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    token = "oauth-sentinel.secret-token"
+    request = httpx.Request(
+        "POST",
+        openai_chatgpt_provider.RESPONSES_URL,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    error_message = f"Authorization: Bearer {token}"
+    stream_request = AsyncMock(side_effect=[
+        httpx.ReadError(error_message, request=request),
+        httpx.ReadError(error_message, request=request),
+    ])
+    log_records = []
+    sink_id = openai_chatgpt_provider.logger.add(
+        lambda message: log_records.append(message.record),
+    )
+
+    try:
+        with (
+            patch("ragnarbot.auth.openai_oauth.get_access_token", return_value=token),
+            patch.object(provider, "_stream_request", stream_request),
+            patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()),
+        ):
+            response = await provider.chat(
+                messages=[{"role": "user", "content": "hi"}],
+                model="openai/gpt-5.5",
+            )
+    finally:
+        openai_chatgpt_provider.logger.remove(sink_id)
+
+    rendered_logs = "\n".join(record["message"] for record in log_records)
+    assert token not in rendered_logs
+    assert token not in (response.content or "")
+    assert "[REDACTED]" in rendered_logs
+    assert all(record["exception"] is None for record in log_records)
+
+
+@pytest.mark.asyncio
+async def test_raw_transport_retries_transient_http_status_only():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    request = httpx.Request("POST", openai_chatgpt_provider.RESPONSES_URL)
+    unavailable = httpx.Response(503, request=request)
+    transient = httpx.HTTPStatusError(
+        "Server error '503 Service Unavailable'",
+        request=request,
+        response=unavailable,
+    )
+    stream_request = AsyncMock(side_effect=[transient, LLMResponse(content="ok")])
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch.object(provider, "_stream_request", stream_request),
+        patch("ragnarbot.providers.openai_chatgpt_provider.asyncio.sleep", AsyncMock()),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.content == "ok"
+    assert stream_request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_raw_transport_does_not_retry_auth_status():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider()
+
+    request = httpx.Request("POST", openai_chatgpt_provider.RESPONSES_URL)
+    unauthorized = httpx.Response(401, request=request)
+    error = httpx.HTTPStatusError(
+        "Client error '401 Unauthorized'",
+        request=request,
+        response=unauthorized,
+    )
+    stream_request = AsyncMock(side_effect=error)
+
+    with (
+        patch("ragnarbot.auth.openai_oauth.get_access_token", return_value="token"),
+        patch.object(provider, "_stream_request", stream_request),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-5.5",
+        )
+
+    assert response.finish_reason == "error"
+    assert "HTTPStatusError" in (response.content or "")
+    assert "401 Unauthorized" in (response.content or "")
+    assert stream_request.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -60,11 +60,17 @@ def test_anthropic_registry_drops_older_models():
     assert "anthropic/claude-opus-4-7" in model_ids
 
 
-def test_openai_models_include_gpt_5_5_first():
+def test_openai_models_include_gpt_5_6_family_first():
     models = get_models("openai")
     model_ids = [m["id"] for m in models]
 
-    assert models[0]["id"] == "openai/gpt-5.5"
+    assert models[0]["id"] == "openai/gpt-5.6-sol"
+    assert model_ids[:3] == [
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
+    ]
+    assert "openai/gpt-5.5" in model_ids
     assert "openai/gpt-5.4" in model_ids
     assert "openai/gpt-5.2" not in model_ids
     assert "openai/gpt-5.4-mini" in model_ids

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -76,6 +76,18 @@ def test_openai_models_include_gpt_5_6_family_first():
     assert "openai/gpt-5.4-mini" in model_ids
 
 
+def test_openai_oauth_models_exclude_raw_transport_incompatible_luna():
+    oauth_model_ids = [model["id"] for model in get_models("openai", "oauth")]
+    api_key_model_ids = [model["id"] for model in get_models("openai", "api_key")]
+
+    assert "openai/gpt-5.6-luna" not in oauth_model_ids
+    assert "openai/gpt-5.6-luna" in api_key_model_ids
+    assert oauth_model_ids[:2] == [
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+    ]
+
+
 def test_openrouter_models_include_gpt_5_5():
     models = get_models("openrouter")
     model_ids = [m["id"] for m in models]

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -117,6 +117,31 @@ def test_resolve_reasoning_opus_47_plus_exposes_xhigh_and_max():
         assert off.anthropic_output_config is None
 
 
+@pytest.mark.parametrize(
+    "model",
+    (
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
+        "gpt-5.6",
+    ),
+)
+def test_resolve_reasoning_gpt_56_exposes_xhigh_and_max(model):
+    ultra = resolve_reasoning(model, "ultra")
+    assert ultra.effective_level == "ultra"
+    assert ultra.reasoning_effort == "xhigh"
+    assert ultra.openai_reasoning == {"effort": "xhigh"}
+
+    maximum = resolve_reasoning(model, "max")
+    assert maximum.effective_level == "max"
+    assert maximum.reasoning_effort == "max"
+    assert maximum.openai_reasoning == {"effort": "max"}
+
+    off = resolve_reasoning(model, "off")
+    assert off.reasoning_effort == "none"
+    assert off.openai_reasoning == {"effort": "none"}
+
+
 def test_resolve_reasoning_max_level_across_families():
     # GPT-5.5 flagship: ultra -> xhigh, max clamps to xhigh (OpenAI has no max).
     gpt_ultra = resolve_reasoning("openai/gpt-5.5", "ultra")
@@ -155,6 +180,19 @@ def test_reasoning_level_max_roundtrips(tmp_path):
 
 
 def test_resolve_lightning_support_matrix():
+    for model in (
+        "gpt-5.6",
+        "openai/gpt-5.6",
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
+    ):
+        for auth_method in ("api_key", "oauth"):
+            gpt_56 = resolve_lightning(model, auth_method, True)
+            assert gpt_56.supported is True
+            assert gpt_56.applies is True
+            assert gpt_56.service_tier == "priority"
+
     supported = resolve_lightning("openai/gpt-5.4", "api_key", True)
     assert supported.supported is True
     assert supported.applies is True
@@ -193,6 +231,20 @@ def test_openai_build_request_includes_reasoning():
     )
 
     assert body["reasoning"] == {"effort": "xhigh"}
+
+
+def test_openai_build_request_uses_max_reasoning_for_gpt_56():
+    with patch("ragnarbot.auth.openai_oauth.get_account_id", return_value="acct_test"):
+        provider = OpenAIChatGPTProvider(default_model="openai/gpt-5.6-sol")
+
+    body = provider._build_request(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="gpt-5.6-terra",
+        reasoning_level="max",
+    )
+
+    assert body["reasoning"] == {"effort": "max"}
 
 
 def test_openai_build_request_skips_priority_service_tier_for_raw_oauth_lightning():
@@ -293,6 +345,24 @@ async def test_litellm_passes_reasoning_effort():
         )
 
     assert mock_acompletion.await_args.kwargs["reasoning_effort"] == "xhigh"
+    assert mock_acompletion.await_args.kwargs["max_tokens"] == 128_000
+
+
+@pytest.mark.asyncio
+async def test_litellm_passes_max_reasoning_effort_for_gpt_56():
+    provider = LiteLLMProvider(api_key="sk-openai", default_model="openai/gpt-5.6-luna")
+    mock_acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+    with (
+        patch("ragnarbot.providers.litellm_provider.acompletion", mock_acompletion),
+        patch("ragnarbot.config.providers.model_supports_vision", return_value=True),
+    ):
+        await provider.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_level="max",
+        )
+
+    assert mock_acompletion.await_args.kwargs["reasoning_effort"] == "max"
     assert mock_acompletion.await_args.kwargs["max_tokens"] == 128_000
 
 

--- a/tests/test_shell_guard.py
+++ b/tests/test_shell_guard.py
@@ -1,11 +1,61 @@
 """Tests for ExecTool safety guard."""
 
+import asyncio
+import os
 import shlex
+import signal
 import sys
 
 import pytest
 
 from ragnarbot.agent.tools.shell import ExecTool
+
+
+def _descendant_command(pid_path, sleep_seconds: int = 30) -> str:
+    code = (
+        "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        f"time.sleep({sleep_seconds})"
+    )
+    child = (
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)} "
+        f"{shlex.quote(str(pid_path))}"
+    )
+    return f"{child} & wait"
+
+
+async def _wait_for_file(path, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not path.exists():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"Timed out waiting for {path}")
+        await asyncio.sleep(0.02)
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_for_pid_exit(pid: int, timeout: float = 2.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _pid_exists(pid):
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.02)
+    return True
+
+
+def _force_kill(pid: int | None) -> None:
+    if pid is None or not _pid_exists(pid):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 
 class TestShellGuardPatterns:
@@ -136,3 +186,42 @@ class TestSafetyGuardToggle:
         )
 
         assert str(target.resolve()) in result
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+class TestShellProcessLifecycle:
+    @pytest.mark.asyncio
+    async def test_timeout_kills_descendant_process(self, tmp_path):
+        pid_path = tmp_path / "timeout-child.pid"
+        pid = None
+        try:
+            result = await ExecTool(timeout=0.5, safety_guard=False).execute(
+                _descendant_command(pid_path)
+            )
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+
+            assert "timed out" in result.lower()
+            assert await _wait_for_pid_exit(pid), "timed-out command left a child process alive"
+        finally:
+            _force_kill(pid)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_descendant_process(self, tmp_path):
+        pid_path = tmp_path / "cancel-child.pid"
+        pid = None
+        task = asyncio.create_task(
+            ExecTool(timeout=30, safety_guard=False).execute(_descendant_command(pid_path))
+        )
+        try:
+            await _wait_for_file(pid_path)
+            pid = int(pid_path.read_text())
+            task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=3)
+            assert await _wait_for_pid_exit(pid), "cancelled command left a child process alive"
+        finally:
+            if not task.done():
+                task.cancel()
+            _force_kill(pid)

--- a/tests/test_update_tool.py
+++ b/tests/test_update_tool.py
@@ -1,12 +1,43 @@
 """Tests for the update tool."""
 
+import asyncio
 import json
+import os
+import signal
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
+import ragnarbot.agent.tools.update as update_module
 from ragnarbot.agent.tools.update import UpdateTool, _parse_version
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_for_pid_exit(pid: int, timeout: float = 2.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _pid_exists(pid):
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.02)
+    return True
+
+
+def _force_kill(pid: int | None) -> None:
+    if pid is None or not _pid_exists(pid):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 # ---------------------------------------------------------------------------
 # _parse_version
@@ -391,3 +422,28 @@ async def test_update_marks_offline_profiles_for_info_only_notice(tool, agent, t
     assert payload["requires_restart"] is False
     assert "target_channel" not in payload
     mock_signal.assert_not_called()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+@pytest.mark.asyncio
+async def test_upgrade_timeout_kills_installer_descendants(tmp_path, monkeypatch):
+    monkeypatch.setattr(update_module, "UPGRADE_TIMEOUT_SECONDS", 0.5)
+    pid_path = tmp_path / "installer-child.pid"
+    parent_code = (
+        "import pathlib, subprocess, sys, time; "
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(30)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(30)"
+    )
+    child_pid = None
+    try:
+        with pytest.raises(RuntimeError, match="timed out"):
+            await UpdateTool._run_subprocess(
+                sys.executable, "-c", parent_code, str(pid_path),
+            )
+
+        child_pid = int(pid_path.read_text())
+        assert await _wait_for_pid_exit(child_pid), "installer timeout left a child alive"
+    finally:
+        _force_kill(child_pid)

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.10.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna model support, full reasoning levels, and Lightning compatibility
- keep fallback routing pinned for an entire tool-using interaction so the reported model matches the model that produced the final answer
- harden OpenAI raw SSE terminal events, protocol call IDs, transient retries, and safe diagnostics
- retry transient Anthropic stream-read failures without duplicating completed work
- terminate complete subprocess trees on timeout/cancellation and bound foreground, background, installer, updater, and browser setup lifetimes
- prevent unsupported Luna and generic GPT-5.6 routes from being selected with the raw ChatGPT OAuth transport
- release as `0.11.3`

## Root causes

The fallback route was recalculated on every tool-loop iteration. A primary failure could therefore hand one iteration to the fallback, then return the final answer to the primary while still displaying a fallback footer.

Shell timeouts killed only the shell leader, leaving package-manager descendants alive. Background jobs also had an unbounded `process.wait()` path after early pipe closure.

The raw OpenAI Responses parser accepted streams without a documented terminal event and used the output-item ID instead of the protocol `call_id` for tool continuation.

## Validation

- 907 tests passed; two pre-existing environment-specific tests were deselected because they hardcode `/Users/lvls/ragnarbot` instead of the actual checkout path
- changed-file Ruff, compileall, and diff checks passed
- live OpenAI OAuth soak: 12/12 Sol/Terra raw requests passed
- live OpenAI tool continuation completed with a server-issued `call_...` ID
- live GPT primary -> Opus fallback -> sticky fallback -> GPT recovery passed
- live Codex Fast checks passed for Sol, Terra, and Luna
- wheel and sdist built as `0.11.3`; Twine metadata checks passed
