### PR TITLE
fix Telegram recovery after gateway restart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.3"
+version = "0.11.4"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 __logo__ = "🤖"

--- a/ragnarbot/channels/telegram.py
+++ b/ragnarbot/channels/telegram.py
@@ -32,6 +32,9 @@ CALLBACK_QUERY_PATTERN = (
     r"^(ctx_mode|reasoning_level|lightning_mode|trace_mode|steering_mode|soul_mode):|^install_codex_cli$"
 )
 
+TELEGRAM_START_TIMEOUT_SECONDS = 30.0
+TELEGRAM_RETRY_DELAY_SECONDS = 5.0
+
 
 async def set_bot_commands(bot, chat_ids: list[int] | None = None) -> None:
     """Ensure bot command menu is up to date across all relevant scopes.
@@ -298,6 +301,8 @@ class TelegramChannel(BaseChannel):
         self._transcription_semaphore = asyncio.Semaphore(2)
         self.media_manager = media_manager
         self._app: Application | None = None
+        self._ready = asyncio.Event()
+        self._stop_event = asyncio.Event()
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[int, asyncio.Task] = {}
         self._grants = PendingGrantStore()
@@ -309,6 +314,45 @@ class TelegramChannel(BaseChannel):
             return
 
         self._running = True
+        self._stop_event.clear()
+
+        while self._running:
+            logger.info("Starting Telegram bot (polling mode)...")
+            try:
+                username = await asyncio.wait_for(
+                    self._connect_once(),
+                    timeout=TELEGRAM_START_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                raise
+            except TimeoutError:
+                logger.warning(
+                    "Telegram startup timed out after "
+                    f"{TELEGRAM_START_TIMEOUT_SECONDS:.0f}s; retrying"
+                )
+                await self._shutdown_app()
+            except Exception as exc:
+                logger.warning(
+                    f"Telegram startup failed ({type(exc).__name__}: {exc}); retrying"
+                )
+                await self._shutdown_app()
+            else:
+                self._ready.set()
+                logger.info(f"Telegram bot @{username} connected")
+                await self._stop_event.wait()
+                break
+
+            if self._running:
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=TELEGRAM_RETRY_DELAY_SECONDS,
+                    )
+                except TimeoutError:
+                    pass
+
+    async def _connect_once(self) -> str:
+        """Build one Telegram application and start its polling loop."""
 
         # Build the application
         self._app = (
@@ -344,15 +388,12 @@ class TelegramChannel(BaseChannel):
             pattern=CALLBACK_QUERY_PATTERN,
         ))
 
-        logger.info("Starting Telegram bot (polling mode)...")
-
         # Initialize and start polling
         await self._app.initialize()
         await self._app.start()
 
         # Get bot info and set commands
         bot_info = await self._app.bot.get_me()
-        logger.info(f"Telegram bot @{bot_info.username} connected")
 
         # Pass known chat IDs (from allow_from) to clear per-chat command overrides
         chat_ids = []
@@ -381,25 +422,51 @@ class TelegramChannel(BaseChannel):
             drop_pending_updates=True  # Ignore old messages on startup
         )
 
-        # Keep running until stopped
-        while self._running:
-            await asyncio.sleep(1)
+        return bot_info.username
 
     async def stop(self) -> None:
         """Stop the Telegram bot."""
         self._running = False
+        self._stop_event.set()
+        await self._shutdown_app()
 
-        if self._app:
-            logger.info("Stopping Telegram bot...")
-            await self._app.updater.stop()
-            await self._app.stop()
-            await self._app.shutdown()
-            self._app = None
+    async def _shutdown_app(self) -> None:
+        """Best-effort cleanup for fully or partially initialized applications."""
+        self._ready.clear()
+        app = self._app
+        self._app = None
+
+        if not app:
+            return
+
+        logger.info("Stopping Telegram bot...")
+        try:
+            if app.updater.running:
+                await app.updater.stop()
+        except Exception as exc:
+            logger.debug(f"Telegram updater cleanup skipped: {exc}")
+        try:
+            if app.running:
+                await app.stop()
+        except Exception as exc:
+            logger.debug(f"Telegram application stop skipped: {exc}")
+        try:
+            await app.shutdown()
+        except Exception as exc:
+            logger.debug(f"Telegram application shutdown skipped: {exc}")
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
+        if not self.bot_token:
+            logger.warning("Telegram bot token not configured")
+            return
+
+        if not self._ready.is_set():
+            logger.info("Telegram bot is connecting; buffering outbound message")
+            await self._ready.wait()
+
         if not self._app:
-            logger.warning("Telegram bot not running")
+            logger.warning("Telegram bot stopped before outbound message could be sent")
             return
 
         try:

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,7 +1,8 @@
-"""Tests for Telegram channel edit and callback behavior."""
+"""Tests for Telegram channel lifecycle, edit, and callback behavior."""
 
+import asyncio
 import re
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import telegram
@@ -24,7 +25,61 @@ def _make_channel() -> tuple[TelegramChannel, MagicMock]:
     app = MagicMock()
     app.bot = bot
     channel._app = app
+    channel._ready.set()
     return channel, bot
+
+
+@pytest.mark.asyncio
+async def test_start_retries_after_startup_timeout():
+    """A stuck Telegram handshake should be cancelled and retried."""
+    channel = TelegramChannel(
+        config=TelegramConfig(enabled=True),
+        bus=MagicMock(),
+        bot_token="test-token",
+    )
+    attempts = 0
+
+    async def connect_once() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            await asyncio.Event().wait()
+        return "test_bot"
+
+    channel._connect_once = connect_once
+    channel._shutdown_app = AsyncMock()
+
+    with (
+        patch("ragnarbot.channels.telegram.TELEGRAM_START_TIMEOUT_SECONDS", 0.01),
+        patch("ragnarbot.channels.telegram.TELEGRAM_RETRY_DELAY_SECONDS", 0.0),
+    ):
+        start_task = asyncio.create_task(channel.start())
+        await asyncio.wait_for(channel._ready.wait(), timeout=1)
+        assert attempts == 2
+        channel._shutdown_app.assert_awaited_once()
+
+        await channel.stop()
+        await asyncio.wait_for(start_task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_send_waits_for_connect_instead_of_dropping_message():
+    """Post-restart messages should remain buffered until Telegram is ready."""
+    channel, bot = _make_channel()
+    channel._ready.clear()
+
+    send_task = asyncio.create_task(channel.send(OutboundMessage(
+        channel="telegram",
+        chat_id="123",
+        content="gateway restarted",
+    )))
+    await asyncio.sleep(0)
+    bot.send_message.assert_not_awaited()
+
+    channel._ready.set()
+    await asyncio.wait_for(send_task, timeout=1)
+
+    bot.send_message.assert_awaited_once()
 
 
 def test_callback_query_pattern_matches_install_and_toggle_callbacks():

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.11.3"
+version = "0.11.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What changed

- bound Telegram startup to 30 seconds and retry failed or stalled handshakes
- clean up partially initialized Telegram applications before retrying
- buffer outbound messages until Telegram polling is ready instead of dropping post-restart responses
- bump the package to v0.11.4

## Root cause

The production self-update restarted the gateway successfully, but the first Telegram API handshake stalled indefinitely. At the same time, the post-update system response reached the outbound dispatcher just before the Telegram channel initialized and was dropped as "bot not running". The gateway and LLM remained healthy while Telegram stayed offline.

## Impact

Transient Telegram API or network stalls now trigger automatic reconnects, and responses generated during reconnect are retained until the channel is ready.

## Validation

- `pytest -q tests/test_telegram_channel.py tests/test_update_tool.py tests/test_restart_tool.py tests/test_cli_commands.py` (32 passed)
- `ruff check ragnarbot/channels/telegram.py tests/test_telegram_channel.py`
- `uv build`
- full suite: 909 passed; 2 unrelated pre-existing failures use hardcoded `/Users/lvls/ragnarbot/...` paths that do not exist in this checkout
