### PR TITLE
fix transient OpenAI transcription disconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.4"
+version = "0.11.5"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 __logo__ = "🤖"

--- a/ragnarbot/providers/transcription.py
+++ b/ragnarbot/providers/transcription.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -15,6 +16,9 @@ OPENAI_TRANSCRIPTION_MODELS = {
     "openai-gpt-4o-transcribe": "gpt-4o-transcribe",
     "openai-gpt-4o-mini-transcribe": "gpt-4o-mini-transcribe",
 }
+
+OPENAI_TRANSCRIPTION_MAX_ATTEMPTS = 2
+OPENAI_TRANSCRIPTION_RETRY_DELAY_SECONDS = 1.0
 
 
 class TranscriptionError(Exception):
@@ -125,19 +129,33 @@ class OpenAITranscriptionProvider(TranscriptionProvider):
 
         try:
             async with httpx.AsyncClient() as client:
-                with open(path, "rb") as f:
-                    response = await client.post(
-                        self.api_url,
-                        headers={"Authorization": f"Bearer {self.api_key}"},
-                        files={"file": (path.name, f), "model": (None, self.model)},
-                        data={"response_format": "json"},
-                        timeout=60.0,
-                    )
-                response.raise_for_status()
-                text = response.json().get("text", "").strip()
-                if not text:
-                    raise TranscriptionError("empty response", "OpenAI returned empty text")
-                return text
+                for attempt in range(1, OPENAI_TRANSCRIPTION_MAX_ATTEMPTS + 1):
+                    try:
+                        with open(path, "rb") as f:
+                            response = await client.post(
+                                self.api_url,
+                                headers={"Authorization": f"Bearer {self.api_key}"},
+                                files={"file": (path.name, f), "model": (None, self.model)},
+                                data={"response_format": "json"},
+                                timeout=60.0,
+                            )
+                    except httpx.TransportError as exc:
+                        if attempt >= OPENAI_TRANSCRIPTION_MAX_ATTEMPTS:
+                            raise
+                        logger.warning(
+                            "OpenAI transcription transport failed "
+                            f"({type(exc).__name__}: {exc}); retrying once"
+                        )
+                        await asyncio.sleep(OPENAI_TRANSCRIPTION_RETRY_DELAY_SECONDS)
+                        continue
+
+                    response.raise_for_status()
+                    text = response.json().get("text", "").strip()
+                    if not text:
+                        raise TranscriptionError("empty response", "OpenAI returned empty text")
+                    return text
+
+                raise AssertionError("OpenAI transcription retry loop exhausted unexpectedly")
         except TranscriptionError:
             raise
         except httpx.HTTPStatusError as e:

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,5 +1,8 @@
 """Tests for transcription providers and factory."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 import pytest
 
 from ragnarbot.auth.credentials import Credentials
@@ -64,6 +67,54 @@ class TestOpenAIProvider:
         provider = OpenAITranscriptionProvider(api_key="sk-test")
         with pytest.raises(TranscriptionError, match="file not found"):
             await provider.transcribe(tmp_path / "nonexistent.ogg")
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_transport_disconnect_once(self, tmp_path):
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"audio")
+        provider = OpenAITranscriptionProvider(api_key="sk-test")
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"text": "hello"}
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = AsyncMock(side_effect=[
+            httpx.RemoteProtocolError("Server disconnected without sending a response"),
+            response,
+        ])
+
+        with (
+            patch("ragnarbot.providers.transcription.httpx.AsyncClient", return_value=client),
+            patch("ragnarbot.providers.transcription.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        ):
+            assert await provider.transcribe(audio_path) == "hello"
+
+        assert client.post.await_count == 2
+        sleep.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_http_status_errors(self, tmp_path):
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"audio")
+        provider = OpenAITranscriptionProvider(api_key="sk-test")
+
+        request = httpx.Request("POST", provider.api_url)
+        response = httpx.Response(401, request=request, text="unauthorized")
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = AsyncMock(return_value=response)
+
+        with patch(
+            "ragnarbot.providers.transcription.httpx.AsyncClient",
+            return_value=client,
+        ):
+            with pytest.raises(TranscriptionError, match="OpenAI API 401"):
+                await provider.transcribe(audio_path)
+
+        client.post.assert_awaited_once()
 
 
 class TestFactory:

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.11.4"
+version = "0.11.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What changed

- retry OpenAI voice transcription once after transient HTTP transport disconnects
- reopen the audio file for the retry so the multipart upload starts from byte zero
- keep HTTP status failures such as authentication errors non-retryable
- bump the package to v0.11.5

## Root cause

Production received a voice message successfully, but OpenAI disconnected before returning the transcription response. The transcription provider made only one request, converted the transient `RemoteProtocolError` directly into a user-visible failure, and never retried.

## Impact

One-off connection resets no longer discard otherwise valid voice messages. Permanent transport failures still return after the single bounded retry, while API status errors fail immediately.

## Validation

- full suite: 911 passed, 2 deselected pre-existing hardcoded-path tests
- `ruff check ragnarbot/providers/transcription.py ragnarbot/channels/telegram.py tests/test_transcription.py tests/test_telegram_channel.py`
- `uv build`
