### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragnarbot-ai"
-version = "0.11.5"
+version = "0.12.0"
 description = "A lightweight personal AI assistant framework"
 requires-python = ">=3.11"
 license = {text = "MIT"}
@@ -62,6 +62,9 @@ packages = ["ragnarbot"]
 
 # Include non-Python files in skills
 [tool.hatch.build]
+artifacts = [
+    "ragnarbot/web/static/**",
+]
 include = [
     "ragnarbot/**/*.py",
     "ragnarbot/skills/**/*.md",

--- a/ragnarbot/__init__.py
+++ b/ragnarbot/__init__.py
@@ -2,5 +2,5 @@
 ragnarbot - A lightweight AI agent framework
 """
 
-__version__ = "0.11.5"
+__version__ = "0.12.0"
 __logo__ = "🤖"

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Verify release archives before they can be uploaded."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from pathlib import Path
+
+FORBIDDEN_PARTS = {
+    ".agents",
+    ".claude",
+    ".codex",
+    "__pycache__",
+    "scratchpad",
+    "webui",
+}
+
+
+def _normalized_names(archive: Path) -> list[str]:
+    if archive.suffix == ".whl":
+        with zipfile.ZipFile(archive) as wheel:
+            return wheel.namelist()
+
+    with tarfile.open(archive, mode="r:gz") as sdist:
+        names = []
+        for member in sdist.getnames():
+            parts = Path(member).parts
+            names.append("/".join(parts[1:]) if len(parts) > 1 else member)
+        return names
+
+
+def _verify_archive(archive: Path, version: str) -> None:
+    names = _normalized_names(archive)
+    lowered = archive.name.lower()
+    normalized_version = version.replace("-", "_")
+
+    if normalized_version not in lowered:
+        raise SystemExit(f"{archive}: filename does not contain version {version}")
+    if "ragnarbot/__init__.py" not in names:
+        raise SystemExit(f"{archive}: package root is missing")
+    if "ragnarbot/web/static/index.html" not in names:
+        raise SystemExit(f"{archive}: Web UI index is missing")
+    if not any(
+        name.startswith("ragnarbot/web/static/assets/") and name.endswith(".js")
+        for name in names
+    ):
+        raise SystemExit(f"{archive}: Web UI JavaScript assets are missing")
+    if not any(
+        name.startswith("ragnarbot/web/static/assets/") and name.endswith(".css")
+        for name in names
+    ):
+        raise SystemExit(f"{archive}: Web UI CSS assets are missing")
+
+    forbidden = []
+    for name in names:
+        parts = set(Path(name).parts)
+        if parts & FORBIDDEN_PARTS or name.endswith((".pyc", ".pyo")):
+            forbidden.append(name)
+    if forbidden:
+        preview = "\n".join(f"  - {name}" for name in forbidden[:20])
+        raise SystemExit(f"{archive}: forbidden release content:\n{preview}")
+
+    print(f"verified {archive} ({len(names)} entries)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dist", type=Path)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    wheels = sorted(args.dist.glob("*.whl"))
+    sdists = sorted(args.dist.glob("*.tar.gz"))
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise SystemExit(
+            f"expected one wheel and one sdist, found {len(wheels)} wheel(s) "
+            f"and {len(sdists)} sdist(s)"
+        )
+
+    for archive in [*wheels, *sdists]:
+        _verify_archive(archive, args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "ragnarbot-ai"
-version = "0.11.5"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.12.0
- include the compiled Web UI in wheel and source-distribution artifacts
- add a release artifact verifier that rejects missing frontend assets, local tooling files, and bytecode
- validate the release with 968 tests, a production frontend build, archive inspection, and an isolated wheel install